### PR TITLE
feat: update support links to route to Charmed HPC resources

### DIFF
--- a/.sphinx/_static/github_issue_links.js
+++ b/.sphinx/_static/github_issue_links.js
@@ -10,18 +10,15 @@ window.onload = function() {
     const link = document.createElement("a");
     link.classList.add("muted-link");
     link.classList.add("github-issue-link");
-    link.text = "Give feedback";
+    link.text = "Ask a question";
     link.href = (
-        github_url
-        + "/issues/new?"
-        + "title=docs%3A+TYPE+YOUR+QUESTION+HERE"
-        + "&body=*Please describe the question or issue you're facing with "
-        + `"${document.title}"`
-        + ".*"
+        github_qa
+        + "&title=%5BQuestion%5D%3A+ADD+YOUR+QUESTION+HERE"
+        + "&body=*Please describe your question or the issue you're facing with Charmed HPC*"
         + "%0A%0A%0A%0A%0A"
         + "---"
         + "%0A"
-        + `*Reported+from%3A+${location.href}*`
+        + `*Redirected+from+document%3A+${location.href}*`
     );
     link.target = "_blank";
 

--- a/.sphinx/_static/github_issue_links.js
+++ b/.sphinx/_static/github_issue_links.js
@@ -14,7 +14,7 @@ window.onload = function() {
     link.href = (
         github_qa
         + "&title=%5BQuestion%5D%3A+ADD+YOUR+QUESTION+HERE"
-        + "&body=*Please describe your question or the issue you're facing with Charmed HPC*"
+        + "&body=*Please+describe+your+question+or+issue+with+Charmed+HPC*"
         + "%0A%0A%0A%0A%0A"
         + "---"
         + "%0A"

--- a/.sphinx/_templates/base.html
+++ b/.sphinx/_templates/base.html
@@ -2,7 +2,7 @@
 
 {% block theme_scripts %}
 <script>
-  const github_url = "{{ github_url }}";
+  const github_qa = "{{ github_qa }}";
 </script>
 {% endblock theme_scripts %}
 

--- a/.sphinx/_templates/footer.html
+++ b/.sphinx/_templates/footer.html
@@ -99,7 +99,7 @@
 
     {% if github_discussions %}
     <div class="ask-github">
-      <a class="muted-link" href="{{ github_qa }}">Ask a question on GitHub</a>
+      <a class="muted-link" href="{{ github_qa }}&title=%5BQuestion%5D%3A+ADD+YOUR+QUESTION+HERE&body=*Please+describe+your+question+or+issue+with+Charmed+HPC*%0A%0A%0A%0A%0A---%0A*Redirected+from+document%3A+{{ pagename }}{{ page_source_suffix }}*">Ask a question on GitHub</a>
     </div>
     {% endif %}
 
@@ -107,7 +107,7 @@
 
     {% if github_issues %}
     <div class="issue-github">
-      <a class="muted-link" href="{{ github_url }}/{{ github_repository }}/issues/new?title=%5BDocumentation%5D%3A%20+ADD+A+TITLE&body=*Please+describe+your+issue*%0A%0A---%0A*Document: {{ pagename }}{{ page_source_suffix }}*">Open a GitHub issue for this page</a>
+      <a class="muted-link" href="{{ github_url }}/{{ github_repository }}/issues/new?title=%5BDocumentation%5D%3A%20+ADD+A+TITLE&body=*Please+describe+your+issue+with+the+documentation*%0A%0A---%0A*Document: {{ pagename }}{{ page_source_suffix }}*">Open a GitHub issue for this page</a>
     </div>
     {% endif %}
 

--- a/.sphinx/_templates/footer.html
+++ b/.sphinx/_templates/footer.html
@@ -5,7 +5,7 @@
   {% if meta %}
     {% if 'sequential_nav' in meta %}
       {% set sequential_nav = meta.sequential_nav %}
-    {% endif %}  
+    {% endif %}
   {% endif %}
   {# mod: Conditional wrappers to control page navigation buttons #}
   {% if sequential_nav != "none" -%}
@@ -91,24 +91,15 @@
     {% endif %}
   </div>
   <div class="right-details">
-
-    {# mod: replaced RTD icons with our links #}
-
-    {% if discourse %}
-    <div class="ask-discourse">
-      <a class="muted-link" href="{{ discourse }}">Ask a question on Discourse</a>
-    </div>
-    {% endif %}
-
-    {% if mattermost %}
-    <div class="ask-mattermost">
-      <a class="muted-link" href="{{ mattermost }}">Ask a question on Mattermost</a>
-    </div>
-    {% endif %}
-
     {% if matrix %}
     <div class="ask-matrix">
       <a class="muted-link" href="{{ matrix }}">Ask a question on Matrix</a>
+    </div>
+    {% endif %}
+
+    {% if github_discussions %}
+    <div class="ask-github">
+      <a class="muted-link" href="{{ github_qa }}">Ask a question on GitHub</a>
     </div>
     {% endif %}
 
@@ -116,12 +107,12 @@
 
     {% if github_issues %}
     <div class="issue-github">
-      <a class="muted-link" href="{{ github_url }}/issues/new?title=doc%3A+ADD+A+TITLE&body=DESCRIBE+THE+ISSUE%0A%0A---%0ADocument: {{ pagename }}{{ page_source_suffix }}">Open a GitHub issue for this page</a>
+      <a class="muted-link" href="{{ github_url }}/{{ github_repository }}/issues/new?title=%5BDocumentation%5D%3A%20+ADD+A+TITLE&body=*Please+describe+your+issue*%0A%0A---%0A*Document: {{ pagename }}{{ page_source_suffix }}*">Open a GitHub issue for this page</a>
     </div>
     {% endif %}
 
     <div class="edit-github">
-      <a class="muted-link" href="{{ github_url }}/edit/{{ github_version }}{{ github_folder }}{{ pagename }}{{ page_source_suffix }}">Edit this page on GitHub</a>
+      <a class="muted-link" href="{{ github_url }}/{{ github_repository }}/edit/{{ github_version }}{{ github_folder }}{{ pagename }}{{ page_source_suffix }}">Edit this page on GitHub</a>
     </div>
     {% endif %}
 

--- a/.sphinx/_templates/header.html
+++ b/.sphinx/_templates/header.html
@@ -21,11 +21,15 @@
         <ul class="more-links-dropdown">
 
           <li>
-            <a href="{{ discourse }}" class="p-navigation__sub-link p-dropdown__link">Forum</a>
+            <a href="{{ matrix }}" class="p-navigation__sub-link p-dropdown__link">Chat on Matrix</a>
           </li>
 
           <li>
-            <a href="{{ github_url }}" class="p-navigation__sub-link p-dropdown__link">GitHub</a>
+            <a href="{{ github_discussions }}" class="p-navigation__sub-link p-dropdown__link">GitHub Discussions</a>
+          </li>
+
+          <li>
+            <a href="{{ github_url }}" class="p-navigation__sub-link p-dropdown__link">Source Code</a>
           </li>
 
         </ul>

--- a/custom_conf.py
+++ b/custom_conf.py
@@ -1,169 +1,49 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Custom Sphinx configuration for Charmed HPC documentation site."""
+
 import datetime
 
-# Custom configuration for the Sphinx documentation builder.
-# All configuration specific to your project should be done in this file.
-#
-# The file is included in the common conf.py configuration file.
-# You can modify any of the settings below or add any configuration that
-# is not covered by the common conf.py file.
-#
-# For the full list of built-in configuration values, see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
-#
-# If you're not familiar with Sphinx and don't want to use advanced
-# features, it is sufficient to update the settings in the "Project
-# information" section.
+project = "Charmed HPC"
+author = "Charmed HPC Authors"
+html_title = project + " documentation"
+copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
 
-############################################################
-### Project information
-############################################################
-
-# Product name
-project = 'Documentation starter pack'
-author = 'Canonical Ltd.'
-
-# The title you want to display for the documentation in the sidebar.
-# You might want to include a version number here.
-# To not display any title, set this option to an empty string.
-html_title = project + ' documentation'
-
-# The default value uses CC-BY-SA as the license and the current year
-# as the copyright year.
-#
-# If your documentation needs a different copyright license, use that
-# instead of 'CC-BY-SA'. Also, if your documentation is included as
-# part of the code repository of your project, it'll inherit the license
-# of the code. So you'll need to specify that license here (instead of
-# 'CC-BY-SA').
-#
-# For static works, it is common to provide the year of first publication.
-# Another option is to give the first year and the current year
-# for documentation that is often changed, e.g. 2022–2023 (note the en-dash).
-#
-# A way to check a GitHub repo's creation date is to obtain a classic GitHub
-# token with 'repo' permissions here: https://github.com/settings/tokens
-# Next, use 'curl' and 'jq' to extract the date from the GitHub API's output:
-#
-# curl -H 'Authorization: token <TOKEN>' \
-#   -H 'Accept: application/vnd.github.v3.raw' \
-#   https://api.github.com/repos/canonical/<REPO> | jq '.created_at'
-
-copyright = '%s CC-BY-SA, %s' % (datetime.date.today().year, author)
-
-## Open Graph configuration - defines what is displayed as a link preview
-## when linking to the documentation from another website (see https://ogp.me/)
-# The URL where the documentation will be hosted (leave empty if you
-# don't know yet)
-# NOTE: If no ogp_* variable is defined (e.g. if you remove this section) the
-# sphinxext.opengraph extension will be disabled.
-ogp_site_url = 'https://canonical-starter-pack.readthedocs-hosted.com/'
-# The documentation website name (usually the same as the product name)
+ogp_site_url = "https://canonical-starter-pack.readthedocs-hosted.com/"
 ogp_site_name = project
-# The URL of an image or logo that is used in the preview
-ogp_image = 'https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg'
-
-# Update with the local path to the favicon for your product
-# (default is the circle of friends)
+ogp_image = "https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg"
 html_favicon = '.sphinx/_static/favicon.png'
-
-# (Some settings must be part of the html_context dictionary, while others
-#  are on root level. Don't move the settings.)
 html_context = {
+    # Product information
+    "product_page": "ubuntu.com/hpc",
+    "product_tag": "_static/tag.png",
 
-    # Change to the link to the website of your product (without "https://")
-    # For example: "ubuntu.com/lxd" or "microcloud.is"
-    # If there is no product website, edit the header template to remove the
-    # link (see the readme for instructions).
-    'product_page': 'documentation.ubuntu.com',
+    # Chat and updates
+    "matrix": "https://matrix.to/#/#hpc:ubuntu.com",
 
-    # Add your product tag (the orange part of your logo, will be used in the
-    # header) to ".sphinx/_static" and change the path here (start with "_static")
-    # (default is the circle of friends)
-    'product_tag': '_static/tag.png',
+    # GitHub
+    "github_url": "https://github.com/charmed-hpc",
+    "github_repository": "docs",
+    "github_version": "main",
+    "github_folder": "/",
+    "github_issues": "enabled",
+    "github_discussions": "https://github.com/orgs/charmed-hpc/discussions",
+    "github_qa": "https://github.com/orgs/charmed-hpc/discussions/new?category=q-a",
 
-    # Change to the discourse instance you want to be able to link to
-    # using the :discourse: metadata at the top of a file
-    # (use an empty value if you don't want to link)
-    'discourse': 'https://discourse.ubuntu.com',
-
-    # Change to the Mattermost channel you want to link to
-    # (use an empty value if you don't want to link)
-    'mattermost': 'https://chat.canonical.com/canonical/channels/documentation',
-
-    # Change to the Matrix channel you want to link to
-    # (use an empty value if you don't want to link)
-    'matrix': 'https://matrix.to/#/#documentation:ubuntu.com',
-
-    # Change to the GitHub URL for your project
-    # This is used, for example, to link to the source files and allow creating GitHub issues directly from the documentation.
-    'github_url': 'https://github.com/canonical/sphinx-docs-starter-pack',
-
-    # Change to the branch for this version of the documentation
-    'github_version': 'main',
-
-    # Change to the folder that contains the documentation
-    # (usually "/" or "/docs/")
-    'github_folder': '/',
-
-    # Change to an empty value if your GitHub repo doesn't have issues enabled.
-    # This will disable the feedback button and the issue link in the footer.
-    'github_issues': 'enabled',
-
-    # Controls the existence of Previous / Next buttons at the bottom of pages
-    # Valid options: none, prev, next, both
-    'sequential_nav': "none",
-
-    # Controls if to display the contributors of a file or not
+    # Footer configuration
+    "sequential_nav": "none",
     "display_contributors": True,
-
-    # Controls time frame for showing the contributors
     "display_contributors_since": ""
 }
 
-# If your project is on documentation.ubuntu.com, specify the project
-# slug (for example, "lxd") here.
 slug = ""
-
-############################################################
-### Redirects
-############################################################
-
-# Set up redirects (https://documatt.gitlab.io/sphinx-reredirects/usage.html)
-# For example: 'explanation/old-name.html': '../how-to/prettify.html',
-# You can also configure redirects in the Read the Docs project dashboard
-# (see https://docs.readthedocs.io/en/stable/guides/redirects.html).
-# NOTE: If this variable is not defined, set to None, or the dictionary is empty,
-# the sphinx_reredirects extension will be disabled.
 redirects = {}
-
-############################################################
-### Link checker exceptions
-############################################################
-
-# Links to ignore when checking links
 linkcheck_ignore = [
     'http://127.0.0.1:8000'
     ]
-
-# Pages on which to ignore anchors
-# (This list will be appended to linkcheck_anchors_ignore_for_url)
 custom_linkcheck_anchors_ignore_for_url = []
-
-############################################################
-### Additions to default configuration
-############################################################
-
-## The following settings are appended to the default configuration.
-## Use them to extend the default functionality.
-
-# Remove this variable to disable the MyST parser extensions.
 custom_myst_extensions = []
-
-# Add custom Sphinx extensions as needed.
-# This array contains recommended extensions that should be used.
-# NOTE: The following extensions are handled automatically and do
-# not need to be added here: myst_parser, sphinx_copybutton, sphinx_design,
-# sphinx_reredirects, sphinxcontrib.jquery, sphinxext.opengraph
 custom_extensions = [
     'sphinx_tabs.tabs',
     'canonical.youtube-links',
@@ -172,51 +52,16 @@ custom_extensions = [
     'canonical.terminal-output',
     'notfound.extension'
     ]
-
-# Add custom required Python modules that must be added to the
-# .sphinx/requirements.txt file.
-# NOTE: The following modules are handled automatically and do not need to be
-# added here: canonical-sphinx-extensions, furo, linkify-it-py, myst-parser,
-# pyspelling, sphinx, sphinx-autobuild, sphinx-copybutton, sphinx-design,
-# sphinx-notfound-page, sphinx-reredirects, sphinx-tabs, sphinxcontrib-jquery,
-# sphinxext-opengraph
 custom_required_modules = []
-
-# Add files or directories that should be excluded from processing.
 custom_excludes = [
     'doc-cheat-sheet*',
     ]
-
-# Add CSS files (located in .sphinx/_static/)
 custom_html_css_files = []
-
-# Add JavaScript files (located in .sphinx/_static/)
 custom_html_js_files = []
-
-## The following settings override the default configuration.
-
-# Specify a reST string that is included at the end of each file.
-# If commented out, use the default (which pulls the reuse/links.txt
-# file into each reST file).
-# custom_rst_epilog = ''
-
-# By default, the documentation includes a feedback button at the top.
-# You can disable it by setting the following configuration to True.
-disable_feedback_button = False
-
-# Add tags that you want to use for conditional inclusion of text
-# (https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#tags)
 custom_tags = []
-
-# If you are using the :manpage: role, set this variable to the URL for the version
-# that you want to link to:
+# custom_rst_epilog = ''
+disable_feedback_button = False
 # manpages_url = "https://manpages.ubuntu.com/manpages/noble/en/man{section}/{page}.{section}.html"
-
-############################################################
-### Additional configuration
-############################################################
-
-## Add any configuration that is not covered by the common conf.py file.
 
 # Define a :center: role that can be used to center the content of table cells.
 rst_prolog = '''


### PR DESCRIPTION
This PR patches the documentation starter pack to support routing to Charmed HPC's GitHub Discussions from the documentation website. 

I enabled support for GitHub Discussions since we cannot use the Ubuntu Discourse as a support forum. We can use the forum for sending out announcements and information about Ubuntu HPC-related events, but it cannot be used as a support forum per its moderation policy.

### Misc.

* I updated the "Additional Resources" tab to route to our Matrix chat, GitHub organisation, and Discussions. I also included relevant links to the HPC pages on the Ubuntu website.
* I changed the `Give Feedback` button to say `Ask a question` because I think `Ask a question` is more inviting to Charmed HPC newcomers. Ideally, if folks are having issues with the documentation, we'll want to redirect them somewhere where they feel comfortable to ask their question or report their challenges. "Give Feedback" makes me feel like I need to be an expert in HPC and know exactly what to criticize within the documentation.