### PR TITLE
feat: add initial landing page for how-to and getting starts sections

### DIFF
--- a/howto/getting-started/index.md
+++ b/howto/getting-started/index.md
@@ -1,0 +1,8 @@
+# Getting started
+
+See the documentation in this section to get started with Charmed HPC.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+```

--- a/howto/index.md
+++ b/howto/index.md
@@ -1,4 +1,16 @@
 (howtos)=
 # How-to guides
 
-🚧 Under construction 🚧
+These how-to guides cover key operations and common tasks in Charmed HPC.
+
+## Get started
+
+To get started with Charmed HPC, you must deploy it on a supported
+machine cloud.
+
+```{toctree}
+:titlesonly:
+:maxdepth: 2
+
+getting-started/index
+```


### PR DESCRIPTION
Small PR to add initial landing page for howto documentation, and a good exploration into how Sphinx renders nested categories. Next step after this is to add documentation for deploying the Slurm charms booth using the command-line and Juju bundles. We can use `sphinx-tabs` to switch between the Juju bundle and Juju CLI instructions.

Only thing I need to figure out is if we need to add any additional info for setting up the underlying cloud substrate of if that is something that needs to be saved for the tutorial or the Juju documentation itself

## Screenshot preview

![image](https://github.com/user-attachments/assets/7600549f-6d05-4ccb-a246-50e1bafa9154)
