### PR TITLE
feat: add how-to for deploying Slurm using both the CLI and a bundle

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -1,0 +1,5 @@
+HPC
+Slurm
+munge
+LXD
+yaml

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -17,7 +17,6 @@ Furo
 Git
 GitHub
 Grafana
-HPC
 IAM
 installable
 JSON

--- a/custom_conf.py
+++ b/custom_conf.py
@@ -32,7 +32,7 @@ html_context = {
     "github_qa": "https://github.com/orgs/charmed-hpc/discussions/new?category=q-a",
 
     # Footer configuration
-    "sequential_nav": "none",
+    "sequential_nav": "both",
     "display_contributors": True,
     "display_contributors_since": ""
 }

--- a/howto/getting-started/deploy-workload-manager.md
+++ b/howto/getting-started/deploy-workload-manager.md
@@ -2,14 +2,14 @@
 relatedlinks: "[Get&#32;started&#32;with&#32;LXD](https://documentation.ubuntu.com/lxd/en/latest/tutorial/first_steps/), [Get&#32;started&#32;with&#32;Juju](https://juju.is/docs/juju/tutorial), [Slurm&#32;website](https://slurm.schedmd.com/overview.html)"
 ---
 
-# Deploy the workload manager
+# Deploy workload manager
 
-An HPC workload manager is the base component of your Charmed HPC cluster.
-All the applications and auxiliary services that can be deployed with Charmed HPC
-are integrated with the workload manager to compose the functionality of your cluster.
+This guide shows you how to deploy the workload manager of your Charmed HPC cluster.
 
-[Slurm](https://slurm.schedmd.com/overview.html) is currently the only
-supported workload manager implementation for Charmed HPC.
+```{note}
+[Slurm](https://slurm.schedmd.com/overview.html) is currently the only supported
+workload manager implementation for Charmed HPC.
+```
 
 ## Prerequisites
 
@@ -20,39 +20,35 @@ will at least need:
 - An initialised [LXD](https://canonical.com/lxd) instance.
 - A [Juju](https://juju.is) client.
 
-## Getting started
+## Initialise the machine cloud
 
-Now, before you can deploy the workload manager of your cluster, you need to:
-
-1. Initialise the machine cloud that will provide the instances that the workload
-   manager's services will run within.
-2. Create the model that will hold the workload manager's services.
-
-### Initialise the machine cloud
-
-To initialise the machine cloud that will provide the instances to your cluster,
+To initialise the machine cloud that will provide the virtual machines for your cluster,
 bootstrap a Juju controller on your LXD instance:
 
 ```shell
 juju bootstrap localhost charmed-hpc-controller
 ```
 
-It will take a few minutes to bootstrap the Juju controller. Once the controller
-has finished bootstrapping, move onto the next step for creating a model for the cluster.
+## Create a model for the cluster
 
-### Create a model for the cluster
-
-To create a Juju model for your cluster, use the following command:
+After initialising the machine cloud, create a model for your cluster:
 
 ```shell
 juju add-model charmed-hpc
 ```
 
-Now you're ready to deploy the workload manager for your Charmed HPC cluster!
+Now deploy the workload manager for your cluster!
 
-## Deploy Slurm
+## Deploy the workload manager
 
-Slurm can be deployed multiple ways using Juju.
+Slurm can be deployed in multiple ways using Juju.
+
+```{important}
+The instructions below pass `virt-type=virtual-machine` as a constraint to the Slurm charms
+to instruct LXD to provide a virtual machine rather than a system container. Slurm does not
+fully work within system containers unless some configuration modifications are applied to
+the default LXD profile.
+```
 
 ```````{tabs}
 
@@ -149,15 +145,3 @@ juju deploy ./bundle.yaml
 ``````
 
 ```````
-
-```{note}
-The instructions above pass `virt-type=virtual-machine` as a constraint to the Slurm charms
-to instruct LXD to provide a virtual machine rather than a system container. Slurm does not
-fully work within system containers unless some configuration modifications are applied to
-the default LXD profile.
-```
-
-Your deployment will become active after a few minutes. The Slurm operators
-will handle exchanging the necessary information such as compute node configuration,
-partition data, and munge keys, so you can sit back and enjoy your coffee while
-the operators handle the hard work ☕

--- a/howto/getting-started/deploy-workload-manager.md
+++ b/howto/getting-started/deploy-workload-manager.md
@@ -1,0 +1,163 @@
+---
+relatedlinks: "[Get&#32;started&#32;with&#32;LXD](https://documentation.ubuntu.com/lxd/en/latest/tutorial/first_steps/), [Get&#32;started&#32;with&#32;Juju](https://juju.is/docs/juju/tutorial), [Slurm&#32;website](https://slurm.schedmd.com/overview.html)"
+---
+
+# Deploy the workload manager
+
+An HPC workload manager is the base component of your Charmed HPC cluster.
+All the applications and auxiliary services that can be deployed with Charmed HPC
+are integrated with the workload manager to compose the functionality of your cluster.
+
+[Slurm](https://slurm.schedmd.com/overview.html) is currently the only
+supported workload manager implementation for Charmed HPC.
+
+## Prerequisites
+
+To successfully deploy the workload manager of your Charmed HPC cluster, you
+will at least need:
+
+- A machine running a [currently supported Ubuntu LTS version](https://ubuntu.com/about/release-cycle).
+- An initialised [LXD](https://canonical.com/lxd) instance.
+- A [Juju](https://juju.is) client.
+
+## Getting started
+
+Now, before you can deploy the workload manager of your cluster, you need to:
+
+1. Initialise the machine cloud that will provide the instances that the workload
+   manager's services will run within.
+2. Create the model that will hold the workload manager's services.
+
+### Initialise the machine cloud
+
+To initialise the machine cloud that will provide the instances to your cluster,
+bootstrap a Juju controller on your LXD instance:
+
+```shell
+juju bootstrap localhost charmed-hpc-controller
+```
+
+It will take a few minutes to bootstrap the Juju controller. Once the controller
+has finished bootstrapping, move onto the next step for creating a model for the cluster.
+
+### Create a model for the cluster
+
+To create a Juju model for your cluster, use the following command:
+
+```shell
+juju add-model charmed-hpc
+```
+
+Now you're ready to deploy the workload manager for your Charmed HPC cluster!
+
+## Deploy Slurm
+
+Slurm can be deployed multiple ways using Juju.
+
+```````{tabs}
+
+``````{group-tab} CLI
+
+To deploy Slurm via the Juju CLI, use the following commands:
+
+```shell
+# Deploy Slurm services.
+juju deploy slurmctld --constraints="virt-type=virtual-machine"
+juju deploy slurmd --constraints="virt-type=virtual-machine"
+juju deploy slurmdbd --constraints="virt-type=virtual-machine"
+juju deploy slurmrestd --constraints="virt-type=virtual-machine"
+juju deploy mysql --channel "8.0/stable"
+juju deploy mysql-router slurmdbd-mysql-router --channel "dpe/beta"
+
+# Integrate services together.
+juju integrate slurmctld:slurmd slurmd:slurmctld
+juju integrate slurmctld:slurmdbd slurmdbd:slurmctld
+juju integrate slurmctld:slurmrestd slurmrestd:slurmctld
+juju integrate slurmdbd-mysql-router:backend-database mysql:database
+juju integrate slurmdbd:database slurmdbd-mysql-router:database
+```
+
+``````
+
+``````{group-tab} Bundle
+
+`````{tabs}
+
+````{group-tab} Charmhub
+
+To deploy Slurm via the Slurm bundle published on [Charmhub](https://charmhub.io/slurm),
+use the following command:
+
+```shell
+juju deploy slurm
+```
+
+````
+
+````{group-tab} bundle.yaml
+
+To deploy Slurm via a Juju bundle file, first open a file named _bundle.yaml_ in
+your favourite text editor, and enter the following YAML content:
+
+```yaml
+description: Deploy a ready-to-go Slurm cluster.
+series: jammy
+name: slurm
+applications:
+  slurmctld:
+    charm: slurmctld
+    constraints: virt-type=virtual-machine
+  slurmd:
+    charm: slurmd
+    constraints: virt-type=virtual-machine
+  slurmdbd:
+    charm: slurmdbd
+    constraints: virt-type=virtual-machine
+  slurmrestd:
+    charm: slurmrestd
+    constraints: virt-type=virtual-machine
+  mysql:
+    charm: mysql
+    channel: 8.0/stable
+  slurmdbd-mysql-router:
+    charm: mysql-router
+    channel: dpe/beta
+relations:
+- - slurmctld:slurmd
+  - slurmd:slurmctld
+- - slurmctld:slurmdbd
+  - slurmdbd:slurmctld
+- - slurmctld:slurmrestd
+  - slurmrestd:slurmctld
+- - slurmdbd-mysql-router:backend-database
+  - mysql:database
+- - slurmdbd:database
+  - slurmdbd-mysql-router:database
+```
+
+Save and close the file after entering the YAML content, and use the following
+command to deploy Slurm using your custom _bundle.yaml_ file:
+
+```shell
+juju deploy ./bundle.yaml
+```
+
+````
+
+`````
+
+``````
+
+```````
+
+```{note}
+The instructions above pass `virt-type=virtual-machine` as a constraint to the Slurm charms
+to instruct LXD to provide a virtual machine rather than a system container. Slurm does not
+fully work within system containers unless some configuration modifications are applied to
+the default LXD profile.
+```
+
+Your deployment will become active after a few minutes. The Slurm operators
+will handle exchanging the necessary information such as compute node configuration,
+partition data, and munge keys, so you can sit back and enjoy your coffee while
+the operators handle the hard work ☕

--- a/howto/getting-started/index.md
+++ b/howto/getting-started/index.md
@@ -2,7 +2,11 @@
 
 See the documentation in this section to get started with Charmed HPC.
 
+## How to deploy Charmed HPC
+
 ```{toctree}
 :titlesonly:
 :maxdepth: 1
+
+deploy-workload-manager
 ```


### PR DESCRIPTION
This PR adds the initial draft for how to deploy Slurm using both the Juju CLI and a bundle.

### Misc.

* Enabled sequential navigation within the doc site so that it is easier for readers to proceed through each howto as they walk through deploying their own Charmed HPC cluster.
* Moved HPC specific terms to `.custom_wordlist.txt` since `.wordlist.txt` is directly from the documentation starter pack and should remain unmodified.

### Page preview

![image](https://github.com/user-attachments/assets/d3de67bf-f975-4a6b-99d9-aa638020ed15)
