### PR TITLE
feat: add how-to for accessing Grafana dashboard

### DIFF
--- a/howto/getting-started/deploy-workload-manager.md
+++ b/howto/getting-started/deploy-workload-manager.md
@@ -3,9 +3,9 @@ relatedlinks: "[Get&#32;started&#32;with&#32;LXD](https://documentation.ubuntu.c
 ---
 
 (deploy-workload-manager)=
-# Deploy workload manager
+# How to deploy the workload manager
 
-This guide shows you how to deploy the workload manager of your Charmed HPC cluster.
+This how-to guide shows you how to deploy the workload manager of your Charmed HPC cluster.
 
 ```{note}
 [Slurm](https://slurm.schedmd.com/overview.html) is currently the only supported

--- a/howto/getting-started/index.md
+++ b/howto/getting-started/index.md
@@ -4,9 +4,12 @@ See the how-to guides in this section for how to get started with Charmed HPC.
 
 ## How to deploy Charmed HPC
 
+- {ref}`deploy-workload-manager`
+
 ```{toctree}
 :titlesonly:
 :maxdepth: 1
+:hidden:
 
-deploy-workload-manager
+Deploy workload manager <deploy-workload-manager>
 ```

--- a/howto/index.md
+++ b/howto/index.md
@@ -12,10 +12,10 @@ taking you through the deployment of your own Charmed HPC cluster.
 
 These how-to guides cover how to connect your Charmed HPC
 cluster to the [Canonical Observability Stack](https://charmhub.io/topics/canonical-observability-stack)
-&mdash; also known as __COS__ &mdash; to observe cluster logs, metrics,
-and alerts.
+&mdash; also known as __COS__ &mdash; to monitor and observe your cluster.
 
 - {ref}`connect-workload-manager-to-cos`
+- {ref}`access-grafana`
 
 ```{toctree}
 :titlesonly:

--- a/howto/index.md
+++ b/howto/index.md
@@ -1,6 +1,7 @@
 (howtos)=
 # How-to guides
 
+(howto-getstarted)=
 ## Getting started
 
 These how-to guides will get you started with Charmed HPC by
@@ -8,7 +9,8 @@ taking you through the deployment of your own Charmed HPC cluster.
 
 - {ref}`deploy-workload-manager`
 
-## Observability
+(howto-observability)=
+## Monitoring and observing Charmed HPC
 
 These how-to guides cover how to connect your Charmed HPC
 cluster to the [Canonical Observability Stack](https://charmhub.io/topics/canonical-observability-stack)

--- a/howto/observability/access-grafana.md
+++ b/howto/observability/access-grafana.md
@@ -1,0 +1,34 @@
+(access-grafana)=
+# How to access the Grafana dashboard
+
+This how-to guide shows you how to access the Grafana dashboard
+to explore and analyse metrics collected from your Charmed HPC cluster.
+
+## Prerequisites
+
+Before accessing the Grafana dashboard, you should have:
+
+- {ref}`Connected your cluster's workload manager to COS <connect-workload-manager-to-cos>`.
+
+## Get the Grafana admin password and URL
+
+To get the admin password and URL for the Grafana dashboard, run the
+`get-admin-password` action on the Grafana application leader:
+
+```shell
+juju run grafana/leader -m cos get-admin-password --wait 1m
+```
+
+## Log into Grafana
+
+Copy the returned URL into the address bar of your preferred web browser to
+open the Grafana login page. Enter __admin__ as the username and the returned
+admin password as the password.
+
+```{important}
+The `get-admin-password` action returns the initial admin password that is
+generated when COS is first deployed. The action will return a notice if the
+initial admin password has been changed by the COS administrator. If this is the
+case, you will need to get either a Grafana account or the admin password from
+your COS administrator.
+```

--- a/howto/observability/connect-workload-manager-to-cos.md
+++ b/howto/observability/connect-workload-manager-to-cos.md
@@ -3,7 +3,7 @@ relatedlinks: "[Get&#32;started&#32;with&#32;COS](https://charmhub.io/topics/can
 ---
 
 (connect-workload-manager-to-cos)=
-# Connect workload manager to COS
+# How to connect your cluster's workload manager to COS
 
 This how-to guide shows you how to connect your cluster's
 workload manager to the Canonical Observability Stack to observe

--- a/howto/observability/index.md
+++ b/howto/observability/index.md
@@ -2,12 +2,17 @@
 
 See the how-to guides in this section for how to connect your Charmed HPC
 cluster to the [Canonical Observability Stack](https://charmhub.io/topics/canonical-observability-stack)
-to observe the cluster's logs, metrics, and alerts.
+to monitor and observe your cluster.
+
+- {ref}`connect-workload-manager-to-cos`
+- {ref}`access-grafana`
 
 ```{toctree}
 :titlesonly:
 :maxdepth: 1
+:hidden:
 
-connect-workload-manager-to-cos
+Connect workload manager to COS <connect-workload-manager-to-cos>
+Access Grafana <access-grafana>
 ```
 

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ high-performance computing clusters ⚛️
 ```{warning}
 Charmed HPC is currently in _pre-alpha_; some things might not work as expected.
 Interested in being an early adopter? Please report any issues you have with
-Charmed HPC on [Github](https://github.com/orgs/charmed-hpc/discussions/new?category=q-a&title=%5BISSUE%5D%3A+ADD+YOUR+ISSUE+HERE&body=*Please+describe+your+question+or+issue+with+Charmed+HPC*%0A%0A%0A%0A%0A---%0A*Redirected+from+document%3A+index.md*)!
+Charmed HPC on [GitHub](https://github.com/orgs/charmed-hpc/discussions/new?category=q-a&title=%5BISSUE%5D%3A+ADD+YOUR+ISSUE+HERE&body=*Please+describe+your+question+or+issue+with+Charmed+HPC*%0A%0A%0A%0A%0A---%0A*Redirected+from+document%3A+index.md*)!
 ```
 
 ---

--- a/index.md
+++ b/index.md
@@ -3,6 +3,12 @@
 🚀 Charmed HPC is a next generation, open source cloud computing stack for supercomputers and
 high-performance computing clusters ⚛️
 
+```{warning}
+Charmed HPC is currently in _pre-alpha_; some things might not work as expected.
+Interested in being an early adopter? Please report any issues you have with
+Charmed HPC on [Github](https://github.com/orgs/charmed-hpc/discussions/new?category=q-a&title=%5BISSUE%5D%3A+ADD+YOUR+ISSUE+HERE&body=*Please+describe+your+question+or+issue+with+Charmed+HPC*%0A%0A%0A%0A%0A---%0A*Redirected+from+document%3A+index.md*)!
+```
+
 ---
 
 ## In this documentation
@@ -20,7 +26,8 @@ your {ref}`first-steps`
 
 __Step-by-step guides__ covering key operations and common tasks
 
-🚧 Under construction 🚧
+- {ref}`howto-getstarted`
+- {ref}`howto-observability`
 
 ```
 


### PR DESCRIPTION
This PR adds the how-to for accessing the Grafana dashboard after connecting the cluster workload manager to COS. 

The PR also updates some of the how-to titles to flow a bit better and be less terse, and updates the site navigation. I also made updates to documentation website landing page. The how-to card now includes links to the current how-to sections that we have.

I also added a warning admonition to the landing page about how Charmed HPC is in _pre-alpha_. The purpose for adding this admonition is that we're still stabilizing some bits with the exporter (we need a Debian package for it) and the COS enabled Slurm charms haven't been rolled into stable yet. It would be good to include a "buyer beware" message, but also invite folks to help by testing things out as early adopters.

### Page previews

#### New how-to

![image](https://github.com/user-attachments/assets/32fa4e14-2c0f-49a4-8e8d-5f16417260a4)

#### Updated landing page

![image](https://github.com/user-attachments/assets/8f1ecb4e-329c-40ba-b960-8a370169b42d)




