### PR TITLE
Correct the bundle in the *deploy-workload-manager.md* file

### DIFF
--- a/howto/getting-started/deploy-workload-manager.md
+++ b/howto/getting-started/deploy-workload-manager.md
@@ -104,18 +104,27 @@ applications:
   slurmctld:
     charm: slurmctld
     constraints: virt-type=virtual-machine
+    channel: latest/edge
+    num_units: 1
   slurmd:
     charm: slurmd
     constraints: virt-type=virtual-machine
+    channel: latest/edge
+    num_units: 1
   slurmdbd:
     charm: slurmdbd
     constraints: virt-type=virtual-machine
+    channel: latest/edge
+    num_units: 1
   slurmrestd:
     charm: slurmrestd
     constraints: virt-type=virtual-machine
+    channel: latest/edge
+    num_units: 1
   mysql:
     charm: mysql
     channel: 8.0/stable
+    num_units: 1
   slurmdbd-mysql-router:
     charm: mysql-router
     channel: dpe/beta


### PR DESCRIPTION
This PR fixes the bundle for deploying the workload manager. As is, the deployment fails on Juju 3.x because Juju tries to find the charms in the `stable` channel ([proof](https://app.warp.dev/block/4M10A506n5YtI57oyQ0uTI)).

Also, in case the channel is fixed, all application will get `unkown` state because there's no unit set for any of them. This PR fixes this behaviour as well by adding the key `num_units` to all applications but `slurmdbd-mysql-router`.