### PR TITLE
feat: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+** @charmed-hpc/charmed-hpc-docs-squad


### PR DESCRIPTION
This PR adds a CODEOWNERS file to this repository that makes it so that anyone on the @charmed-hpc/charmed-hpc-docs-squad team will be automatically notified and tagged as a reviewer when a new PR is opened against the repo.

Currently I have just added myself and @AshleyCliff added to the team with the idea that Ashley will be the primary reviewer, and I will come in as the backup reviewer when necessary. Trying out `CODEOWNERS` here before expanding to other the repositories.