### PR TITLE
docs: add initial GPU explanation

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -1,6 +1,7 @@
 HPC
 hostname
 Slurm
+slurm
 sackd
 munge
 LXD
@@ -21,7 +22,8 @@ Terraform
 terraform
 Traefik
 GRES
+gres
 PCIe
 Nvidia
 RESource
-
+conf

--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -24,6 +24,5 @@ Traefik
 GRES
 gres
 PCIe
-Nvidia
 RESource
 conf

--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -20,3 +20,8 @@ autonomizing
 Terraform
 terraform
 Traefik
+GRES
+PCIe
+Nvidia
+RESource
+

--- a/explanation/gpus/driver.md
+++ b/explanation/gpus/driver.md
@@ -1,5 +1,7 @@
 (driver)=
-# Driver auto-install
+# GPU driver installation and management
+
+## Auto-install
 
 Charmed HPC installs GPU drivers when the `slurmd` charm is deployed on a compute node equipped with a supported Nvidia GPU. Driver detection is performed via the API for [`ubuntu-drivers-common`](https://documentation.ubuntu.com/server/how-to/graphics/install-nvidia-drivers/#the-recommended-way-ubuntu-drivers-tool), a package which examines node hardware, determines appropriate third-party drivers and recommends a set of driver packages that are installed from the Ubuntu repositories.
 

--- a/explanation/gpus/driver.md
+++ b/explanation/gpus/driver.md
@@ -3,7 +3,7 @@
 
 ## Auto-install
 
-Charmed HPC installs GPU drivers when the `slurmd` charm is deployed on a compute node equipped with a supported Nvidia GPU. Driver detection is performed via the API for [`ubuntu-drivers-common`](https://documentation.ubuntu.com/server/how-to/graphics/install-nvidia-drivers/#the-recommended-way-ubuntu-drivers-tool), a package which examines node hardware, determines appropriate third-party drivers and recommends a set of driver packages that are installed from the Ubuntu repositories.
+Charmed HPC installs GPU drivers when the `slurmd` charm is deployed on a compute node equipped with a supported NVIDIA GPU. Driver detection is performed via the API for [`ubuntu-drivers-common`](https://documentation.ubuntu.com/server/how-to/graphics/install-nvidia-drivers/#the-recommended-way-ubuntu-drivers-tool), a package which examines node hardware, determines appropriate third-party drivers and recommends a set of driver packages that are installed from the Ubuntu repositories.
 
 ## Libraries used
 

--- a/explanation/gpus/driver.md
+++ b/explanation/gpus/driver.md
@@ -1,0 +1,8 @@
+(driver)=
+# Driver auto-install
+
+Charmed HPC installs GPU drivers when the `slurmd` charm is deployed on a compute node equipped with a supported Nvidia GPU. Driver detection is performed via the API to [`ubuntu-drivers-common`](https://documentation.ubuntu.com/server/how-to/graphics/install-nvidia-drivers/#the-recommended-way-ubuntu-drivers-tool), a package which examines node hardware, determines appropriate third-party drivers and recommends a set of driver packages that are installed from the Ubuntu repositories.
+
+## Libraries used
+
+- [`ubuntu-drivers-common`](https://github.com/canonical/ubuntu-drivers-common), from GitHub.

--- a/explanation/gpus/driver.md
+++ b/explanation/gpus/driver.md
@@ -1,7 +1,7 @@
 (driver)=
 # Driver auto-install
 
-Charmed HPC installs GPU drivers when the `slurmd` charm is deployed on a compute node equipped with a supported Nvidia GPU. Driver detection is performed via the API to [`ubuntu-drivers-common`](https://documentation.ubuntu.com/server/how-to/graphics/install-nvidia-drivers/#the-recommended-way-ubuntu-drivers-tool), a package which examines node hardware, determines appropriate third-party drivers and recommends a set of driver packages that are installed from the Ubuntu repositories.
+Charmed HPC installs GPU drivers when the `slurmd` charm is deployed on a compute node equipped with a supported Nvidia GPU. Driver detection is performed via the API for [`ubuntu-drivers-common`](https://documentation.ubuntu.com/server/how-to/graphics/install-nvidia-drivers/#the-recommended-way-ubuntu-drivers-tool), a package which examines node hardware, determines appropriate third-party drivers and recommends a set of driver packages that are installed from the Ubuntu repositories.
 
 ## Libraries used
 

--- a/explanation/gpus/index.md
+++ b/explanation/gpus/index.md
@@ -11,6 +11,6 @@ A Graphics Processing Unit (GPU) is a specialized hardware resource that was ori
 :maxdepth: 1
 :hidden:
 
-Driver auto-install <driver>
+Drivers <driver>
 Slurm enlistment <slurmconf>
 ```

--- a/explanation/gpus/index.md
+++ b/explanation/gpus/index.md
@@ -1,0 +1,16 @@
+(gpus)=
+# GPUs
+
+A Graphics Processing Unit (GPU) is a specialized hardware resource that was originally designed to accelerate computer graphics calculations but now has expanded use in general purpose computing across a number of fields. GPU-enabled workloads are supported on a Charmed HPC cluster with the necessary driver and workload manager configuration automatically handled by the charms.
+
+- {ref}`driver`
+- {ref}`slurmconf`
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+:hidden:
+
+Driver auto-install <driver>
+Slurm enlistment <slurmconf>
+```

--- a/explanation/gpus/index.md
+++ b/explanation/gpus/index.md
@@ -1,7 +1,7 @@
 (gpus)=
 # GPUs
 
-A Graphics Processing Unit (GPU) is a specialized hardware resource that was originally designed to accelerate computer graphics calculations but now has expanded use in general purpose computing across a number of fields. GPU-enabled workloads are supported on a Charmed HPC cluster with the necessary driver and workload manager configuration automatically handled by the charms.
+A Graphics Processing Unit (GPU) is a specialized hardware resource that was originally designed to accelerate computer graphics calculations but has expanded use in general purpose computing across a number of fields. GPU-enabled workloads are supported on a Charmed HPC cluster with the necessary driver and workload manager configuration automatically handled by the charms.
 
 - {ref}`driver`
 - {ref}`slurmconf`

--- a/explanation/gpus/slurmconf.md
+++ b/explanation/gpus/slurmconf.md
@@ -1,0 +1,31 @@
+(slurmconf)=
+# Slurm enlistment
+
+To allow cluster users to submit jobs requesting GPUs, detected GPUs are automatically added to the [Generic RESource (GRES) Slurm configuration](https://slurm.schedmd.com/gres.html). This is a feature in Slurm which enables scheduling of arbitrary generic resources, including GPUs.
+
+## Device details
+
+GPU details are gathered by [`pynvml`](https://pypi.org/project/nvidia-ml-py/), the official Python bindings for the Nvidia management library, which enables GPU counts, associated device files and model names to be queried from the drivers. For compatibility with Slurm configuration files, retrieved model names are converted to lowercase and white space is replaced with underscores. “Tesla T4” becomes `tesla_t4`, for example.
+
+## Slurm configuration
+
+Each GPU-equipped node is added to the `gres.conf` configuration file as its own `NodeName` entry, following the format defined in the [Slurm `gres.conf` documentation](https://slurm.schedmd.com/gres.conf.html). Individual `NodeName` entries are used over an entry per GRES resource to provide greater support for heterogeneous environments, such as a cluster where the same model of GPU is not consistently the same device file across compute nodes.
+
+In `slurm.conf`, the configuration for GPU-equipped nodes has a comma-separated list in its `Gres=` element, giving the name, type and count for each GPU on the node.
+
+For example, a Microsoft Azure Standard_NC24ads_A100_v4 node, equipped with a NVIDIA A100 PCIe GPU, is given a node configuration in `slurm.conf` of:
+
+```
+NodeName=juju-e33208-1 CPUs=24 Boards=1 SocketsPerBoard=1 CoresPerSocket=24 ThreadsPerCore=1 RealMemory=221446 Gres=gpu:nvidia_a100_80gb_pcie:1 MemSpecLimit=1024
+```
+
+and corresponding `gres.conf` line:
+
+```
+NodeName=juju-e33208-1 Name=gpu Type=nvidia_a100_80gb_pcie File=/dev/nvidia0
+```
+
+## Libraries used
+
+- [`pynvml / nvidia-ml-py`](https://pypi.org/project/nvidia-ml-py/), from PyPI.
+

--- a/explanation/gpus/slurmconf.md
+++ b/explanation/gpus/slurmconf.md
@@ -1,7 +1,7 @@
 (slurmconf)=
 # Slurm enlistment
 
-To allow cluster users to submit jobs requesting GPUs, detected GPUs are automatically added to the [Generic RESource (GRES) Slurm configuration](https://slurm.schedmd.com/gres.html). This is a feature in Slurm which enables scheduling of arbitrary generic resources, including GPUs.
+To allow cluster users to submit jobs requesting GPUs, detected GPUs are automatically added to the [Generic RESource (GRES) Slurm configuration](https://slurm.schedmd.com/gres.html). GRES is a feature in Slurm which enables scheduling of arbitrary generic resources, including GPUs.
 
 ## Device details
 
@@ -9,9 +9,16 @@ GPU details are gathered by [`pynvml`](https://pypi.org/project/nvidia-ml-py/), 
 
 ## Slurm configuration
 
-Each GPU-equipped node is added to the `gres.conf` configuration file as its own `NodeName` entry, following the format defined in the [Slurm `gres.conf` documentation](https://slurm.schedmd.com/gres.conf.html). Individual `NodeName` entries are used over an entry per GRES resource to provide greater support for heterogeneous environments, such as a cluster where the same model of GPU is not consistently the same device file across compute nodes.
+Each GPU-equipped node is added to the `gres.conf` configuration file following the format defined in the [Slurm `gres.conf` documentation](https://slurm.schedmd.com/gres.conf.html). A single `gres.conf` is shared by all compute nodes in the cluster, using the optional `NodeName` specification to define GPU resources per node. Each line in `gres.conf` consists of the following parameters:
 
-In `slurm.conf`, the configuration for GPU-equipped nodes has a comma-separated list in its `Gres=` element, giving the name, type and count for each GPU on the node.
+| Parameter  | Value                                                      |
+| ---------- | ---------------------------------------------------------- |
+| `NodeName` | Node the `gres.conf` line applies to.                      |
+| `Name`     | Name of the generic resource. Always `gpu` here.           |
+| `Type`     | GPU model name.                                            |
+| `File`     | Path of the device file(s) associated with this GPU model. |
+
+In `slurm.conf`, the configuration for GPU-equipped nodes has a comma-separated list in its `Gres=` element, giving the name, type, and count for each GPU on the node.
 
 For example, a Microsoft Azure `Standard_NC24ads_A100_v4` node, equipped with a NVIDIA A100 PCIe GPU, is given a node configuration in `slurm.conf` of:
 

--- a/explanation/gpus/slurmconf.md
+++ b/explanation/gpus/slurmconf.md
@@ -1,3 +1,7 @@
+---
+relatedlinks: "[Slurm&#32;Workload&#32;Manager&#32;-&#32;gres.conf](https://slurm.schedmd.com/gres.conf.html)"
+---
+
 (slurmconf)=
 # Slurm enlistment
 

--- a/explanation/gpus/slurmconf.md
+++ b/explanation/gpus/slurmconf.md
@@ -13,7 +13,7 @@ Each GPU-equipped node is added to the `gres.conf` configuration file as its own
 
 In `slurm.conf`, the configuration for GPU-equipped nodes has a comma-separated list in its `Gres=` element, giving the name, type and count for each GPU on the node.
 
-For example, a Microsoft Azure Standard_NC24ads_A100_v4 node, equipped with a NVIDIA A100 PCIe GPU, is given a node configuration in `slurm.conf` of:
+For example, a Microsoft Azure `Standard_NC24ads_A100_v4` node, equipped with a NVIDIA A100 PCIe GPU, is given a node configuration in `slurm.conf` of:
 
 ```
 NodeName=juju-e33208-1 CPUs=24 Boards=1 SocketsPerBoard=1 CoresPerSocket=24 ThreadsPerCore=1 RealMemory=221446 Gres=gpu:nvidia_a100_80gb_pcie:1 MemSpecLimit=1024

--- a/explanation/gpus/slurmconf.md
+++ b/explanation/gpus/slurmconf.md
@@ -13,7 +13,7 @@ GPU details are gathered by [`pynvml`](https://pypi.org/project/nvidia-ml-py/), 
 
 ## Slurm configuration
 
-Each GPU-equipped node is added to the _gres.conf_ configuration file following the format defined in the [Slurm _gres.conf_ documentation](https://slurm.schedmd.com/gres.conf.html). A single _gres.conf_ is shared by all compute nodes in the cluster, using the optional `NodeName` specification to define GPU resources per node. Each line in _gres.conf_ consists of the following parameters:
+Each GPU-equipped node is added to the _gres.conf_ configuration file following the format defined in the [Slurm _gres.conf_ documentation](https://slurm.schedmd.com/gres.conf.html). A single _gres.conf_ is shared by all compute nodes in the cluster, using the optional `NodeName` specification to define GPU resources per node. Each line in _gres.conf_ uses the following parameters to define a GPU resource:
 
 | Parameter  | Value                                                      |
 | ---------- | ---------------------------------------------------------- |
@@ -22,7 +22,7 @@ Each GPU-equipped node is added to the _gres.conf_ configuration file following 
 | `Type`     | GPU model name.                                            |
 | `File`     | Path of the device file(s) associated with this GPU model. |
 
-In _slurm.conf_, the configuration for GPU-equipped nodes has a comma-separated list in its `Gres=` element, giving the name, type, and count for each GPU on the node.
+In _slurm.conf_, if a node is GPU-equipped, its configuration line includes an additional `Gres=`, element, containing a comma-separated list of GPU configurations. If a node is not GPU-equipped, its configuration line does not contain `Gres=`. The format for each configuration is: `<name>:<type>:<count>`, as seen in the example below.
 
 For example, a Microsoft Azure `Standard_NC24ads_A100_v4` node, equipped with a NVIDIA A100 PCIe GPU, is given a node configuration in _slurm.conf_ of:
 

--- a/explanation/gpus/slurmconf.md
+++ b/explanation/gpus/slurmconf.md
@@ -9,7 +9,7 @@ To allow cluster users to submit jobs requesting GPUs, detected GPUs are automat
 
 ## Device details
 
-GPU details are gathered by [`pynvml`](https://pypi.org/project/nvidia-ml-py/), the official Python bindings for the Nvidia management library, which enables GPU counts, associated device files and model names to be queried from the drivers. For compatibility with Slurm configuration files, retrieved model names are converted to lowercase and white space is replaced with underscores. “Tesla T4” becomes `tesla_t4`, for example.
+GPU details are gathered by [`pynvml`](https://pypi.org/project/nvidia-ml-py/), the official Python bindings for the NVIDIA management library, which enables GPU counts, associated device files and model names to be queried from the drivers. For compatibility with Slurm configuration files, retrieved model names are converted to lowercase and white space is replaced with underscores. “Tesla T4” becomes `tesla_t4`, for example.
 
 ## Slurm configuration
 

--- a/explanation/gpus/slurmconf.md
+++ b/explanation/gpus/slurmconf.md
@@ -13,24 +13,24 @@ GPU details are gathered by [`pynvml`](https://pypi.org/project/nvidia-ml-py/), 
 
 ## Slurm configuration
 
-Each GPU-equipped node is added to the `gres.conf` configuration file following the format defined in the [Slurm `gres.conf` documentation](https://slurm.schedmd.com/gres.conf.html). A single `gres.conf` is shared by all compute nodes in the cluster, using the optional `NodeName` specification to define GPU resources per node. Each line in `gres.conf` consists of the following parameters:
+Each GPU-equipped node is added to the _gres.conf_ configuration file following the format defined in the [Slurm _gres.conf_ documentation](https://slurm.schedmd.com/gres.conf.html). A single _gres.conf_ is shared by all compute nodes in the cluster, using the optional `NodeName` specification to define GPU resources per node. Each line in _gres.conf_ consists of the following parameters:
 
 | Parameter  | Value                                                      |
 | ---------- | ---------------------------------------------------------- |
-| `NodeName` | Node the `gres.conf` line applies to.                      |
+| `NodeName` | Node the _gres.conf_ line applies to.                      |
 | `Name`     | Name of the generic resource. Always `gpu` here.           |
 | `Type`     | GPU model name.                                            |
 | `File`     | Path of the device file(s) associated with this GPU model. |
 
-In `slurm.conf`, the configuration for GPU-equipped nodes has a comma-separated list in its `Gres=` element, giving the name, type, and count for each GPU on the node.
+In _slurm.conf_, the configuration for GPU-equipped nodes has a comma-separated list in its `Gres=` element, giving the name, type, and count for each GPU on the node.
 
-For example, a Microsoft Azure `Standard_NC24ads_A100_v4` node, equipped with a NVIDIA A100 PCIe GPU, is given a node configuration in `slurm.conf` of:
+For example, a Microsoft Azure `Standard_NC24ads_A100_v4` node, equipped with a NVIDIA A100 PCIe GPU, is given a node configuration in _slurm.conf_ of:
 
 ```
 NodeName=juju-e33208-1 CPUs=24 Boards=1 SocketsPerBoard=1 CoresPerSocket=24 ThreadsPerCore=1 RealMemory=221446 Gres=gpu:nvidia_a100_80gb_pcie:1 MemSpecLimit=1024
 ```
 
-and corresponding `gres.conf` line:
+and corresponding _gres.conf_ line:
 
 ```
 NodeName=juju-e33208-1 Name=gpu Type=nvidia_a100_80gb_pcie File=/dev/nvidia0

--- a/explanation/index.md
+++ b/explanation/index.md
@@ -2,8 +2,7 @@
 # Explanation
 
 - {ref}`cryptography`
-
-🚧 Under construction 🚧
+- {ref}`GPUs`
 
 ```{toctree}
 :titlesonly:
@@ -11,4 +10,5 @@
 :hidden:
 
 cryptography/index
+gpus/index
 ```

--- a/reference/gres/index.md
+++ b/reference/gres/index.md
@@ -1,11 +1,11 @@
 (gres)=
 # Generic Resource (GRES) Scheduling
 
-Each line in `gres.conf` uses the following parameters to define a GPU resource:
+Each line in _gres.conf_ uses the following parameters to define a GPU resource:
 
 | Parameter  | Value                                                      |
 | ---------- | ---------------------------------------------------------- |
-| `NodeName` | Node the `gres.conf` line applies to.                      |
+| `NodeName` | Node the _gres.conf_ line applies to.                      |
 | `Name`     | Name of the generic resource. Always `gpu`.           |
 | `Type`     | GPU model name.                                            |
 | `File`     | Path of the device file(s) associated with this GPU model. |

--- a/reference/gres/index.md
+++ b/reference/gres/index.md
@@ -1,0 +1,11 @@
+(gres)=
+# Generic Resource (GRES) Scheduling
+
+Each line in `gres.conf` uses the following parameters to define a GPU resource:
+
+| Parameter  | Value                                                      |
+| ---------- | ---------------------------------------------------------- |
+| `NodeName` | Node the `gres.conf` line applies to.                      |
+| `Name`     | Name of the generic resource. Always `gpu`.           |
+| `Type`     | GPU model name.                                            |
+| `File`     | Path of the device file(s) associated with this GPU model. |

--- a/reference/index.md
+++ b/reference/index.md
@@ -1,4 +1,12 @@
 (reference)=
 # Reference
 
-🚧 Under construction 🚧
+- {ref}`gres`
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+:hidden:
+
+gres/index
+```


### PR DESCRIPTION
Adds sections to Explanation for the GPU support recently merged into the Slurm charms. Once we have Reference docs, we'll likely want to update these sections to include links to at least a table of supported GPU models.

I've gone with `Driver auto-install` and `Slurm enlistment` as subsection titles but wonder if these should be `GPU driver auto-install` and `Slurm enlistment of GPUs`. This would make the context obvious when, e.g., looking through search results, however would mean a lot of repetition of "GPU". Let me know your thoughts.