### PR TITLE
feat(header): rename `Source Code` to `GitHub Organization`

### DIFF
--- a/.sphinx/_templates/header.html
+++ b/.sphinx/_templates/header.html
@@ -29,7 +29,7 @@
           </li>
 
           <li>
-            <a href="{{ github_url }}" class="p-navigation__sub-link p-dropdown__link">Source Code</a>
+            <a href="{{ github_url }}" class="p-navigation__sub-link p-dropdown__link">GitHub Organization</a>
           </li>
 
         </ul>


### PR DESCRIPTION
`Source Code` is a misnomer since it doesn't navigate the reader to the full source code of Charmed HPC; it just takes you to a collection of a couple of repositories. `GitHub Organization` is better since it helps folks get connected with the project on GitHub, not necessarily dump them in a hodgepodge of repositories.