### PR TITLE
feat: add how-to for initializing cloud environment of Charmed HPC

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -80,5 +80,3 @@ filesystems
 integrations
 lifecycle
 runnable
-## From `per se`
-se

--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -38,8 +38,11 @@ hostname
 hostnames
 
 # Clouds
+aks
 aws
+maas
 microsoft
+OpenStack
 
 # Developer jargon/acronyms
 conf
@@ -55,6 +58,7 @@ RSA
 Uid
 URIs
 yaml
+TLS
 
 # Filesystem jargon
 Ceph
@@ -76,3 +80,5 @@ filesystems
 integrations
 lifecycle
 runnable
+## From `per se`
+se

--- a/howto/getting-started/deploy-shared-filesystem.md
+++ b/howto/getting-started/deploy-shared-filesystem.md
@@ -7,7 +7,7 @@ deploy `filesystem-client` to integrate with externally managed shared filesyste
 
 ## Prerequisites
 
-- {ref}`deploy-slurm`.
+- A [deployed Slurm cluster](#howto-getting-started-deploy-slurm).
 
 ## Deploy an external filesystem server
 
@@ -25,7 +25,7 @@ To integrate with an external NFS server, you will require:
 - The exported path.
 - (optional) the port.
 
-Each public cloud has its own procedure to deploy a public NFS server. Provided here are links to  
+Each public cloud has its own procedure to deploy a public NFS server. Provided here are links to
 the set up procedures on a few well-known public clouds.
 
 ::::{grid} 1 1 2 2
@@ -88,7 +88,7 @@ exit
 
 
 After gathering all the required information, you can deploy the `nfs-server-proxy` charm in order to
-expose the externally managed server inside a Juju model. 
+expose the externally managed server inside a Juju model.
 
 :::{code-block} shell
 juju deploy nfs-server-proxy --config \
@@ -109,7 +109,7 @@ To integrate with an external CephFS share, you will require:
  - The username with permissions to access the filesystem.
  - The cephx key for the username.
 
-Here, a Ceph cluster will be set up using [MicroCeph][ceph]. 
+Here, a Ceph cluster will be set up using [MicroCeph][ceph].
 
 [ceph]: https://canonical-microceph.readthedocs-hosted.com/en/squid-stable
 
@@ -182,7 +182,7 @@ exit
 :::
 
 Having collected all the required information, you can deploy the `cephfs-server-proxy` charm to
-expose the externally managed Ceph filesystem inside a Juju model. 
+expose the externally managed Ceph filesystem inside a Juju model.
 
 :::{code-block} shell
 juju deploy cephfs-server-proxy --config \
@@ -199,7 +199,7 @@ juju deploy cephfs-server-proxy --config \
 
 ## Deploy the filesystem-client
 
-To add the `filesystem-client` charm, which mounts a shared filesystem to the cluster nodes: 
+To add the `filesystem-client` charm, which mounts a shared filesystem to the cluster nodes:
 
 :::{code-block} shell
 juju deploy filesystem-client --channel latest/edge \

--- a/howto/getting-started/deploy-slurm.md
+++ b/howto/getting-started/deploy-slurm.md
@@ -1,8 +1,8 @@
 ---
-relatedlinks: "[Get&#32;started&#32;with&#32;Juju](https://juju.is/docs/juju/tutorial), [Slurm&#32;website](https://slurm.schedmd.com/overview.html), [Slurm&#32;charms&#32;repository](https://github.com/charmed-hpc/slurm-charms)"
+relatedlinks: "[Slurm&#32;website](https://slurm.schedmd.com/overview.html), [Slurm&#32;charms&#32;repository](https://github.com/charmed-hpc/slurm-charms)"
 ---
 
-(deploy-slurm)=
+(howto-getting-started-deploy-slurm)=
 # How to deploy Slurm
 
 This how-to guide shows you how to deploy the Slurm workload manager as the
@@ -13,8 +13,7 @@ The deployment, management, and operations of Slurm are controlled by the Slurm 
 
 To successfully deploy Slurm in your Charmed HPC cluster, you will at least need:
 
-- A machine running a [currently supported Ubuntu LTS version](https://ubuntu.com/about/release-cycle).
-- [A bootstrapped Juju controller on a supported machine cloud](https://juju.is/docs/juju/juju-supported-clouds).
+- An [initialized cloud environment](#howto-getting-started-initialize-cloud-environment).
 - The [Juju CLI client](https://juju.is/docs/juju/install-and-manage-the-client) installed on your machine.
 
 Once you have verified that you have met the prerequisites above, proceed to the instructions below.
@@ -44,10 +43,10 @@ deployment. The `slurm` model is the abstraction that will hold the resources &m
 machines, integrations, network spaces, storage, etc. &mdash; that are provisioned as
 part of your Slurm deployment.
 
-Run the following command to create the `slurm` model:
+Run the following command to create the `slurm` model in your `charmed-hpc` machine cloud:
 
 :::{code-block} shell
-juju add-model slurm
+juju add-model slurm charmed-hpc
 :::
 
 Now, with `slurm` model created, run the following set of commands to deploy the Slurm
@@ -122,7 +121,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.15.0"
+      version = ">= 0.16.0"
     }
   }
 }
@@ -137,6 +136,10 @@ resource will direct Juju to create the model `slurm`:
 :caption: `main.tf`
 resource "juju_model" "slurm" {
   name = "slurm"
+
+  cloud {
+    name = "charmed-hpc"
+  }
 }
 :::
 
@@ -267,13 +270,17 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.15.0"
+      version = ">= 0.16.0"
     }
   }
 }
 
 resource "juju_model" "slurm" {
   name = "slurm"
+
+  cloud {
+    name = "charmed-hpc"
+  }
 }
 
 module "sackd" {

--- a/howto/getting-started/index.md
+++ b/howto/getting-started/index.md
@@ -4,7 +4,8 @@ See the how-to guides in this section for how to get started with Charmed HPC.
 
 ## How to deploy Charmed HPC
 
-- {ref}`deploy-slurm`
+- {ref}`howto-getting-started-initialize-cloud-environment`
+- {ref}`howto-getting-started-deploy-slurm`
 - {ref}`deploy-shared-filesystem`
 
 :::{toctree}
@@ -12,6 +13,7 @@ See the how-to guides in this section for how to get started with Charmed HPC.
 :maxdepth: 1
 :hidden:
 
+Initialize cloud environment <initialize-cloud-environment>
 Deploy Slurm <deploy-slurm>
 Deploy a shared filesystem <deploy-shared-filesystem>
 :::

--- a/howto/getting-started/initialize-cloud-environment.md
+++ b/howto/getting-started/initialize-cloud-environment.md
@@ -1,36 +1,37 @@
 ---
-relatedlinks: "[Get&#032;started&#032;with&#032;Juju](https://juju.is/docs/juju/tutorial), [Juju&#032;(Cloud)&#032;](https://juju.is/docs/juju/cloud), [Juju&#032;(Controller)&#032;](https://juju.is/docs/juju/controller)"
+relatedlinks: "[Get&#032;started&#032;with&#032;Juju](https://juju.is/docs/juju/tutorial), [Juju&#032;(Application)](https://juju.is/docs/juju/application), [Juju&#032;(Charm)](https://juju.is/docs/juju/charmed-operator), [Juju&#032;(Cloud)](https://juju.is/docs/juju/cloud), [Juju&#032;(Controller)](https://juju.is/docs/juju/controller)"
 ---
 
 (howto-getting-started-initialize-cloud-environment)=
 # How to initialize cloud environment
 
 This how-to guide shows you how to initialize the cloud environment where you will
-deploy your Charmed HPC cluster to.
+deploy your Charmed HPC cluster.
 
 Charmed HPC uses a converged architecture where a machine cloud hosts compute plane
-applications like the cluster's workload manager and filesystem, and a Kubernetes cloud
+applications like the cluster's workload manager and filesystem, and a Kubernetes (K8s) cloud
 hosts common control plane applications like identity management and observability services.
-We __strongly recommend__ pairing your machine cloud with a complimenting Kubernetes cloud
+It is __strongly recommended__ that you pair your machine cloud with a complimenting Kubernetes cloud
 to simplify the deployment and management of both clouds. For example, LXD should be paired
-with Canonical Kubernetes, Azure paired with AKS, AWS paired with EKS, etc.
+with Canonical Kubernetes, Azure paired with AKS, AWS paired with EKS, and so on.
 
 :::{note}
 To Charmed HPC, a __cloud__ (or ___backing cloud___) is any entity that has an API that can
 provide compute, networking, and optionally storage resources to applications deployed on them.
 This includes public clouds such as Amazon Web Services, Google Compute Engine, Microsoft Azure
 and Kubernetes as well as private OpenStack-based clouds. Charmed HPC can also make use of
-environments, such as MAAS and LXD, which are not clouds per se, but can be treated as a cloud.
+environments, such as MAAS and LXD, which are not necessarily considered clouds, but can be treated
+as a cloud.
 :::
 
 ## Prerequisites
 
-To successfully initialize the cloud environment where you will deploy your Charmed HPC cluster,
-you will at least need:
+To initialize the cloud environment where you will deploy your Charmed HPC cluster,
+you will need:
 
-* Access to a [supported machine cloud](https://juju.is/docs/juju/juju-supported-clouds).
-* Access to a [supported Kubernetes cloud](https://juju.is/docs/juju/juju-supported-clouds).
-* The [Juju CLI client](https://juju.is/docs/juju/install-and-manage-the-client) installed on your machine.
+* Access to a [supported machine cloud](https://juju.is/docs/juju/juju-supported-clouds)
+* Access to a [supported Kubernetes cloud](https://juju.is/docs/juju/juju-supported-clouds)
+* The [Juju CLI client](https://juju.is/docs/juju/install-and-manage-the-client) installed on your machine
 
 (howto-getting-started-initialize-machine-cloud)=
 ## Initialize machine cloud
@@ -46,17 +47,17 @@ Follow the instructions below to initialize the `charmed-hpc` machine cloud.
 
 To use LXD as the machine cloud for your Charmed HPC cluster, you will need to have:
 
-* [Installed LXD](https://documentation.ubuntu.com/lxd/en/stable-5.21/installing/).
-* [Initialized LXD](https://documentation.ubuntu.com/lxd/en/stable-5.21/howto/initialize/).
-* [Exposed LXD to the network](https://documentation.ubuntu.com/lxd/en/stable-5.21/howto/server_expose/).
-* [Configured a server trust password](https://documentation.ubuntu.com/lxd/en/stable-5.21/server/#server-core:core.trust_password).
+* [Installed LXD](https://documentation.ubuntu.com/lxd/en/stable-5.21/installing/)
+* [Initialized LXD](https://documentation.ubuntu.com/lxd/en/stable-5.21/howto/initialize/)
+* [Exposed LXD to the network](https://documentation.ubuntu.com/lxd/en/stable-5.21/howto/server_expose/)
+* [Configured a server trust password](https://documentation.ubuntu.com/lxd/en/stable-5.21/server/#server-core:core.trust_password)
 
 :::{hint}
 If you're unfamiliar with operating an LXD server, see the [First steps with LXD](https://documentation.ubuntu.com/lxd/en/latest/tutorial/first_steps/)
-tutorial for high-level introduction to LXD.
+tutorial for a high-level introduction to LXD.
 :::
 
-### Add LXD cloud with `juju add-cloud`{l=shell}
+### Add LXD cloud to Juju
 
 To make your LXD cloud known to Juju, first create the file _charmed-hpc-cloud.yaml_ and enter the following
 content, substituting `<public address of lxd server>` with the public address of your LXD server:
@@ -80,7 +81,7 @@ your LXD cloud to Juju:
 juju add-cloud charmed-hpc --file ./charmed-hpc-cloud.yaml
 :::
 
-### Add LXD cloud credentials with `juju add-credential`{l=shell}
+### Add LXD cloud credentials to Juju
 
 Before you can start deploying applications on your LXD server, you must add credentials for contacting
 your LXD server to Juju. Create the file _charmed-hpc-cloud-credentials.yaml_ and enter the following content, with
@@ -97,7 +98,7 @@ credentials:
       trust-password: <lxd server trust password>
 :::
 
-Now use `juju add-credential`{l=shell} to add your the credentials for contacting your LXD server to Juju:
+Now use `juju add-credential`{l=shell} to add the credentials for contacting your LXD server to Juju:
 
 :::{code-block} shell
 juju add-credential charmed-hpc --file ./charmed-hpc-cloud-credentials.yaml
@@ -141,7 +142,7 @@ Machine  State    Address        Inst id        Base          AZ  Message
 
 ## Initialize Kubernetes cloud
 
-After initializing the `charmed-hpc` machine cloud, for the instructions below to initialize the
+After initializing the `charmed-hpc` machine cloud, follow the instructions below to initialize the
 `charmed-hpc-k8s` Kubernetes cloud.
 
 :::::{tab-set}
@@ -151,11 +152,12 @@ After initializing the `charmed-hpc` machine cloud, for the instructions below t
 
 ### Prerequisites for Canonical Kubernetes
 
-To use Canonical K8s as the Kubernetes cloud for your Charmed HPC cluster, you will need to have:
+To use Canonical Kubernetes as the Kubernetes cloud for your Charmed HPC cluster,
+you will need to have:
 
-* [Initialized a machine cloud](#howto-getting-started-initialize-machine-cloud).
-* [Installed and bootstrapped Canonical Kubernetes](https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/howto/install/snap/).
-* [Enabled the default load balancer](https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/howto/networking/default-loadbalancer/).
+* [Initialized a machine cloud](#howto-getting-started-initialize-machine-cloud)
+* [Installed and bootstrapped Canonical Kubernetes](https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/howto/install/snap/)
+* [Enabled the default load balancer](https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/howto/networking/default-loadbalancer/)
 
 :::{hint}
 If you're unfamiliar with operating a Canonical Kubernetes cluster, see the
@@ -170,7 +172,7 @@ machine cloud, pipe the output of `k8s config view`{l=shell} to `juju add-k8s`{l
 following command:
 
 :::{code-block} shell
-sudo k8s config view | \
+sudo k8s config | \
   juju add-k8s --controller charmed-hpc-controller charmed-hpc-k8s
 :::
 
@@ -190,3 +192,9 @@ charmed-hpc-k8s  1        default  k8s
 ::::
 
 :::::
+
+## Next Steps
+
+Now that both the `charmed-hpc` machine cloud and `charmed-hpc-k8s` Kubernetes cloud are initialized,
+you can start deploying applications with Juju. Go to the {ref}`howto-getting-started-deploy-slurm` guide
+for how to deploy Slurm as the first application of your Charmed HPC cluster.

--- a/howto/getting-started/initialize-cloud-environment.md
+++ b/howto/getting-started/initialize-cloud-environment.md
@@ -168,7 +168,7 @@ for a high-level introduction to Canonical Kubernetes.
 ### Add Canonical Kubernetes cloud to deployed controller
 
 To make your Canonical Kubernetes cloud known to Juju and use the same controller as your
-machine cloud, pipe the output of `k8s config view`{l=shell} to `juju add-k8s`{l=shell} by running the
+machine cloud, pipe the output of `k8s config`{l=shell} to `juju add-k8s`{l=shell} by running the
 following command:
 
 :::{code-block} shell
@@ -197,4 +197,4 @@ charmed-hpc-k8s  1        default  k8s
 
 Now that both the `charmed-hpc` machine cloud and `charmed-hpc-k8s` Kubernetes cloud are initialized,
 you can start deploying applications with Juju. Go to the {ref}`howto-getting-started-deploy-slurm` guide
-for how to deploy Slurm as the first application of your Charmed HPC cluster.
+for how to deploy Slurm as the workload manager of your Charmed HPC cluster.

--- a/howto/getting-started/initialize-cloud-environment.md
+++ b/howto/getting-started/initialize-cloud-environment.md
@@ -1,0 +1,192 @@
+---
+relatedlinks: "[Get&#032;started&#032;with&#032;Juju](https://juju.is/docs/juju/tutorial), [Juju&#032;(Cloud)&#032;](https://juju.is/docs/juju/cloud), [Juju&#032;(Controller)&#032;](https://juju.is/docs/juju/controller)"
+---
+
+(howto-getting-started-initialize-cloud-environment)=
+# How to initialize cloud environment
+
+This how-to guide shows you how to initialize the cloud environment where you will
+deploy your Charmed HPC cluster to.
+
+Charmed HPC uses a converged architecture where a machine cloud hosts compute plane
+applications like the cluster's workload manager and filesystem, and a Kubernetes cloud
+hosts common control plane applications like identity management and observability services.
+We __strongly recommend__ pairing your machine cloud with a complimenting Kubernetes cloud
+to simplify the deployment and management of both clouds. For example, LXD should be paired
+with Canonical Kubernetes, Azure paired with AKS, AWS paired with EKS, etc.
+
+:::{note}
+To Charmed HPC, a __cloud__ (or ___backing cloud___) is any entity that has an API that can
+provide compute, networking, and optionally storage resources to applications deployed on them.
+This includes public clouds such as Amazon Web Services, Google Compute Engine, Microsoft Azure
+and Kubernetes as well as private OpenStack-based clouds. Charmed HPC can also make use of
+environments, such as MAAS and LXD, which are not clouds per se, but can be treated as a cloud.
+:::
+
+## Prerequisites
+
+To successfully initialize the cloud environment where you will deploy your Charmed HPC cluster,
+you will at least need:
+
+* Access to a [supported machine cloud](https://juju.is/docs/juju/juju-supported-clouds).
+* Access to a [supported Kubernetes cloud](https://juju.is/docs/juju/juju-supported-clouds).
+* The [Juju CLI client](https://juju.is/docs/juju/install-and-manage-the-client) installed on your machine.
+
+(howto-getting-started-initialize-machine-cloud)=
+## Initialize machine cloud
+
+Follow the instructions below to initialize the `charmed-hpc` machine cloud.
+
+:::::{tab-set}
+
+::::{tab-item} LXD
+:sync: lxd
+
+### Prerequisites for LXD
+
+To use LXD as the machine cloud for your Charmed HPC cluster, you will need to have:
+
+* [Installed LXD](https://documentation.ubuntu.com/lxd/en/stable-5.21/installing/).
+* [Initialized LXD](https://documentation.ubuntu.com/lxd/en/stable-5.21/howto/initialize/).
+* [Exposed LXD to the network](https://documentation.ubuntu.com/lxd/en/stable-5.21/howto/server_expose/).
+* [Configured a server trust password](https://documentation.ubuntu.com/lxd/en/stable-5.21/server/#server-core:core.trust_password).
+
+:::{hint}
+If you're unfamiliar with operating an LXD server, see the [First steps with LXD](https://documentation.ubuntu.com/lxd/en/latest/tutorial/first_steps/)
+tutorial for high-level introduction to LXD.
+:::
+
+### Add LXD cloud with `juju add-cloud`{l=shell}
+
+To make your LXD cloud known to Juju, first create the file _charmed-hpc-cloud.yaml_ and enter the following
+content, substituting `<public address of lxd server>` with the public address of your LXD server:
+
+:::{code-block} yaml
+:caption: `charmed-hpc-cloud.yaml`
+:linenos:
+
+clouds:
+  charmed-hpc:
+    type: lxd
+    description: "Machine cloud for Charmed HPC"
+    auth-types: [certificate, interactive]
+    endpoint: <public address of lxd server>
+:::
+
+Now, after creating _charmed-hpc-cloud.yaml_, use `juju add-cloud`{l=shell} to add
+your LXD cloud to Juju:
+
+:::{code-block} shell
+juju add-cloud charmed-hpc --file ./charmed-hpc-cloud.yaml
+:::
+
+### Add LXD cloud credentials with `juju add-credential`{l=shell}
+
+Before you can start deploying applications on your LXD server, you must add credentials for contacting
+your LXD server to Juju. Create the file _charmed-hpc-cloud-credentials.yaml_ and enter the following content, with
+`<lxd server trust password>` substituted with your LXD server's configured trust password:
+
+:::{code-block} yaml
+:caption: `charmed-hpc-cloud-credentials.yaml`
+:linenos:
+
+credentials:
+  charmed-hpc:
+    accesskey:
+      auth-type: interactive
+      trust-password: <lxd server trust password>
+:::
+
+Now use `juju add-credential`{l=shell} to add your the credentials for contacting your LXD server to Juju:
+
+:::{code-block} shell
+juju add-credential charmed-hpc --file ./charmed-hpc-cloud-credentials.yaml
+:::
+
+:::{note}
+Juju will use your LXD server's configured trust password to automatically retrieve your server's TLS certificates.
+:::
+
+### Bootstrap LXD cloud controller
+
+With both your LXD server's endpoint and credentials added to Juju, use `juju bootstrap`{l=shell} to deploy
+the cloud controller:
+
+:::{code-block} shell
+juju bootstrap charmed-hpc charmed-hpc-controller
+:::
+
+After a few minutes, your LXD cloud controller will become active. The output of `juju status`{l=shell}
+command should be similar to the following:
+
+:::{terminal}
+:input: juju status -m controller
+
+Model       Controller              Cloud/Region         Version  SLA          Timestamp
+controller  charmed-hpc-controller  charmed-hpc/default  3.6.2    unsupported  13:55:33-05:00
+
+App         Version  Status  Scale  Charm            Channel     Rev  Exposed  Message
+controller           active      1  juju-controller  3.6/stable  116  no
+
+Unit           Workload  Agent  Machine  Public address  Ports  Message
+controller/0*  active    idle   0        10.190.89.114
+
+Machine  State    Address        Inst id        Base          AZ  Message
+0        started  10.190.89.114  juju-3b4cde-0  ubuntu@24.04      Running
+:::
+
+::::
+
+:::::
+
+## Initialize Kubernetes cloud
+
+After initializing the `charmed-hpc` machine cloud, for the instructions below to initialize the
+`charmed-hpc-k8s` Kubernetes cloud.
+
+:::::{tab-set}
+
+::::{tab-item} Canonical Kubernetes
+:sync: lxd
+
+### Prerequisites for Canonical Kubernetes
+
+To use Canonical K8s as the Kubernetes cloud for your Charmed HPC cluster, you will need to have:
+
+* [Initialized a machine cloud](#howto-getting-started-initialize-machine-cloud).
+* [Installed and bootstrapped Canonical Kubernetes](https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/howto/install/snap/).
+* [Enabled the default load balancer](https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/howto/networking/default-loadbalancer/).
+
+:::{hint}
+If you're unfamiliar with operating a Canonical Kubernetes cluster, see the
+[Canonical Kubernetes tutorials](https://documentation.ubuntu.com/canonical-kubernetes/latest/snap/tutorial/)
+for a high-level introduction to Canonical Kubernetes.
+:::
+
+### Add Canonical Kubernetes cloud to deployed controller
+
+To make your Canonical Kubernetes cloud known to Juju and use the same controller as your
+machine cloud, pipe the output of `k8s config view`{l=shell} to `juju add-k8s`{l=shell} by running the
+following command:
+
+:::{code-block} shell
+sudo k8s config view | \
+  juju add-k8s --controller charmed-hpc-controller charmed-hpc-k8s
+:::
+
+`juju add-k8s`{l=shell} will immediately add your Canonical Kubernetes cloud to the controller of your machine
+cloud. The output of `juju clouds`{l=shell} should be similar to the following:
+
+:::{terminal}
+:input: juju clouds --controller charmed-hpc-controller
+
+
+Clouds available on the controller:
+Cloud            Regions  Default  Type
+charmed-hpc      1        default  lxd
+charmed-hpc-k8s  1        default  k8s
+:::
+
+::::
+
+:::::

--- a/howto/index.md
+++ b/howto/index.md
@@ -9,7 +9,8 @@ The guides in this section provide detailed steps for key operations and common 
 These how-to guides will get you started with Charmed HPC by
 taking you through the deployment of your own Charmed HPC cluster.
 
-- {ref}`deploy-slurm`
+- {ref}`howto-getting-started-initialize-cloud-environment`
+- {ref}`howto-getting-started-deploy-slurm`
 - {ref}`deploy-shared-filesystem`
 
 (howto-observability)=

--- a/howto/observability/connect-slurm-to-cos.md
+++ b/howto/observability/connect-slurm-to-cos.md
@@ -14,7 +14,7 @@ To successfully connect Slurm to COS, you must have:
 
 - [A deployed COS cloud](https://charmhub.io/topics/canonical-observability-stack/tutorials)
   with [ingress enabled](https://charmhub.io/topics/canonical-observability-stack/explanation/ingress).
-- {ref}`A deployed Slurm cluster. <deploy-slurm>`
+- A [deployed Slurm cluster](#howto-getting-started-deploy-slurm).
 - The [Juju CLI client](https://juju.is/docs/juju/install-and-manage-the-client) installed on your machine.
 
 Once you have verified that you have met the prerequisites above, proceed to the instructions below.


### PR DESCRIPTION
Like PR title says, this PR adds a how-to for initializing the cloud environment which we will deploy Charmed HPC in. Currently I just started off with LXD and Canonical Kubernetes since I want to get the structure of the page correct, but ideally we'll be able to expand it as we start to bring on more clouds such as Azure and AWS.

### Related issues

* Resolves #20 

### Misc.

* Removed extraneous whitespace.
* Linked "Deploy Slurm" how-to to "Initialize cloud environment" how-to.
* Updated "Deploy Slurm" how-to to include info about deploying Slurm to the created machine cloud `charmed-hpc`
  * In the Identity how-to I will be deploying the Identity charms like glauth-k8s to the Kubernetes cloud `charmed-hpc-k8s`
* I further granularized the reference links we've created to reduce the chances of name clashes between reference links.