### PR TITLE
docs(rdma): initial interconnects Explanation and Reference sections

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -1,9 +1,17 @@
 # Charmed HPC-specific jargon
+ConnectX
+EFA
 GRES
 gres
 HPC
 hpc
+InfiniBand
+MPI
+OpenMPI
+PKEY
+RDMA
 RESource
+UCX
 
 # Charm/application/service names
 alertmanager
@@ -52,8 +60,11 @@ PCIe
 proxying
 PyPI
 RSA
+subnet
 Uid
 URIs
+userspace
+VMs
 yaml
 
 # Filesystem jargon
@@ -75,4 +86,6 @@ filesystem
 filesystems
 integrations
 lifecycle
+Performant
+performant
 runnable

--- a/explanation/index.md
+++ b/explanation/index.md
@@ -5,6 +5,7 @@ Discussion and clarification for various topics related to Charmed HPC.
 
 - {ref}`cryptography`
 - {ref}`GPUs`
+- {ref}`explanation-interconnects`
 
 ```{toctree}
 :titlesonly:
@@ -13,4 +14,5 @@ Discussion and clarification for various topics related to Charmed HPC.
 
 cryptography/index
 gpus/index
+interconnects/index
 ```

--- a/explanation/interconnects/driver.md
+++ b/explanation/interconnects/driver.md
@@ -7,7 +7,7 @@ Charmed HPC installs [`rdma-core`](https://github.com/linux-rdma/rdma-core) from
 
 ### OpenMPI UCX override
 
-The `openmpi-bin` package from Debian and Ubuntu repositories ships with [Unified Communication X UCX](https://openucx.org/) disabled in configuration file `/etc/openmpi/openmpi-mca-params.conf`. UCX is a framework designed for high-performance computing communication and is the default preferred communication method for InfiniBand networks in OpenMPI. With UCX disabled, OpenMPI falls back to other communication methods, which can be less performant. In order to improve performance on InfiniBand Charmed HPC clusters, UCX is re-enabled by the `slurmd` charm on install. The parameters in `/etc/openmpi/openmpi-mca-params.conf` are overridden to remove all instances of `ucx` and `uct` from the lists of disabled OpenMPI components. For example:
+Debian and Ubuntu repositories ship the `openmpi-bin` package with [Unified Communication X UCX](https://openucx.org/) disabled in configuration file `/etc/openmpi/openmpi-mca-params.conf`. UCX is a framework designed for high-performance computing communication and is the default preferred communication method for InfiniBand networks in OpenMPI. With UCX disabled, OpenMPI falls back to other communication methods, which can be less performant. In order to improve performance on InfiniBand Charmed HPC clusters, UCX is re-enabled by the `slurmd` charm on install. The parameters in `/etc/openmpi/openmpi-mca-params.conf` are overridden to remove all instances of `ucx` and `uct` from the lists of disabled OpenMPI components. For example:
 
 ```
 mtl = ^ofi

--- a/explanation/interconnects/driver.md
+++ b/explanation/interconnects/driver.md
@@ -1,0 +1,31 @@
+(explanation-rdma-driver)=
+# Interconnect driver installation and management
+
+## Auto-install
+
+Charmed HPC installs [`rdma-core`](https://github.com/linux-rdma/rdma-core) from the operating system repositories when the `slurmd` charm is deployed on a compute node. The `rdma-core` package automatically detects available interconnect hardware and sets up the appropriate userspace libraries and services to enable RDMA. Drivers for supported NVIDIA ConnectX InfiniBand adapters are provided automatically by the operating system kernel. The [`openmpi-bin`](https://www.open-mpi.org/) package is installed from repositories on compute nodes to allow for the running of MPI applications.
+
+### OpenMPI UCX override
+
+The `openmpi-bin` package from Debian and Ubuntu repositories ships with [Unified Communication X UCX](https://openucx.org/) disabled in configuration file `/etc/openmpi/openmpi-mca-params.conf`. UCX is a framework designed for high-performance computing communication and is the default preferred communication method for InfiniBand networks in OpenMPI. With UCX disabled, OpenMPI falls back to other communication methods, which can be less performant. In order to improve performance on InfiniBand Charmed HPC clusters, UCX is re-enabled by the `slurmd` charm on install. The parameters in `/etc/openmpi/openmpi-mca-params.conf` are overridden to remove all instances of `ucx` and `uct` from the lists of disabled OpenMPI components. For example:
+
+```
+mtl = ^ofi
+btl = ^uct,openib,ofi
+pml = ^ucx
+osc = ^ucx,pt2pt
+```
+
+becomes:
+
+```
+mtl = ^ofi
+btl = ^openib,ofi
+osc = ^pt2pt
+```
+
+## Interconnect management
+
+High-speed interconnects typically require management software to orchestrate the communication between nodes. This software can be referred to as a subnet manager or fabric manager. Implementation is cloud-specific, with public clouds often providing a managed solution without access to the management software. For implementation details on supported clouds, refer to:
+
+- {ref}`reference-interconnects`

--- a/explanation/interconnects/driver.md
+++ b/explanation/interconnects/driver.md
@@ -7,7 +7,7 @@ Charmed HPC installs [`rdma-core`](https://github.com/linux-rdma/rdma-core) from
 
 ### OpenMPI UCX override
 
-Debian and Ubuntu repositories ship the `openmpi-bin` package with [Unified Communication X UCX](https://openucx.org/) disabled in configuration file `/etc/openmpi/openmpi-mca-params.conf`. UCX is a framework designed for high-performance computing communication and is the default preferred communication method for InfiniBand networks in OpenMPI. With UCX disabled, OpenMPI falls back to other communication methods, which can be less performant. In order to improve performance on InfiniBand Charmed HPC clusters, UCX is re-enabled by the `slurmd` charm on install. The parameters in `/etc/openmpi/openmpi-mca-params.conf` are overridden to remove all instances of `ucx` and `uct` from the lists of disabled OpenMPI components. For example:
+Debian and Ubuntu repositories ship the `openmpi-bin` package with [Unified Communication X UCX](https://openucx.org/) disabled in configuration file `/etc/openmpi/openmpi-mca-params.conf` in order to [suppress warning messages](https://github.com/open-mpi/ompi/issues/8367) when running on a system without a high-speed interconnect. UCX is a framework designed for high-performance computing communication and is the default preferred communication method for InfiniBand networks in OpenMPI. With UCX disabled, OpenMPI falls back to other communication methods, which can be less performant. In order to improve performance on InfiniBand Charmed HPC clusters, UCX is re-enabled by the `slurmd` charm on install. The parameters in `/etc/openmpi/openmpi-mca-params.conf` are overridden to remove all instances of `ucx` and `uct` from the lists of disabled OpenMPI components. For example:
 
 ```
 mtl = ^ofi

--- a/explanation/interconnects/index.md
+++ b/explanation/interconnects/index.md
@@ -1,0 +1,16 @@
+(explanation-interconnects)=
+# High-speed interconnects
+
+A high-speed interconnect is a networking technology which enables performant communication and data transfer between nodes in a cluster. Communication is both high-bandwidth (large throughput) and low-latency (minimal delay). Performant communication is particularly beneficial for applications which can span multiple compute nodes, such as applications that employ the Message Passing Interface (MPI) standard for parallel computing.
+
+This performance is achieved through Remote Direct Memory Access (RDMA): a mechanism that enables a networked (remote) computer to directly access the memory of another computer, independently of either computer's CPU and operating system. NVIDIA InfiniBand is a common implementation of RDMA.
+
+- {ref}`explanation-rdma-driver`
+
+```{toctree}
+:titlesonly:
+:maxdepth: 1
+:hidden:
+
+Drivers <driver>
+```

--- a/reference/index.md
+++ b/reference/index.md
@@ -6,8 +6,9 @@ Charmed HPC operates.
 
 ## General information
 
-* {ref}`reference-underlying-projects-and-dependencies`
-* {ref}`gres`
+- {ref}`reference-underlying-projects-and-dependencies`
+- {ref}`gres`
+- {ref}`reference-interconnects`
 
 ```{toctree}
 :titlesonly:
@@ -16,4 +17,5 @@ Charmed HPC operates.
 
 Underlying projects and dependencies <underlying-projects-and-dependencies>
 gres/index
+interconnects/index
 ```

--- a/reference/interconnects/index.md
+++ b/reference/interconnects/index.md
@@ -3,7 +3,7 @@
 
 :::{csv-table}
 :header: >
-: cloud, interconnect, instance availability, subnet management, deployment notes
+: cloud, interconnect, instance availability, subnet management, deployment notes for charmed hpc
 
 [Amazon Web Services](https://aws.amazon.com/), [Elastic Fabric Adapter (EFA)](https://aws.amazon.com/hpc/efa/), [Supported instance types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types), Provided by cloud, **Not supported** <!-- [Manual setup documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html) -->
 [Microsoft Azure](https://portal.azure.com), [InfiniBand](https://learn.microsoft.com/en-us/azure/virtual-machines/setup-infiniband), [RDMA-capable instances](https://learn.microsoft.com/en-us/azure/virtual-machines/setup-infiniband#rdma-capable-instances), Provided by cloud, VMs in the same [availability set](https://learn.microsoft.com/en-us/azure/virtual-machines/availability-set-overview) have the same InfiniBand PKEY.<br><br>All units in a Juju application are deployed in the same availability set automatically.

--- a/reference/interconnects/index.md
+++ b/reference/interconnects/index.md
@@ -1,10 +1,14 @@
 (reference-interconnects)=
 # Public cloud high-speed interconnects
 
+<!--
+TODO:
+[Amazon Web Services](https://aws.amazon.com/), [Elastic Fabric Adapter (EFA)](https://aws.amazon.com/hpc/efa/), [Supported instance types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types), Provided by cloud, [Setup documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html)
+-->
+
 :::{csv-table}
 :header: >
 : cloud, interconnect, instance availability, subnet management, deployment notes for charmed hpc
 
-[Amazon Web Services](https://aws.amazon.com/), [Elastic Fabric Adapter (EFA)](https://aws.amazon.com/hpc/efa/), [Supported instance types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types), Provided by cloud, **Not supported** <!-- [Manual setup documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html) -->
 [Microsoft Azure](https://portal.azure.com), [InfiniBand](https://learn.microsoft.com/en-us/azure/virtual-machines/setup-infiniband), [RDMA-capable instances](https://learn.microsoft.com/en-us/azure/virtual-machines/setup-infiniband#rdma-capable-instances), Provided by cloud, VMs in the same [availability set](https://learn.microsoft.com/en-us/azure/virtual-machines/availability-set-overview) have the same InfiniBand PKEY.<br><br>All units in a Juju application are deployed in the same availability set automatically.
 :::

--- a/reference/interconnects/index.md
+++ b/reference/interconnects/index.md
@@ -1,0 +1,10 @@
+(reference-interconnects)=
+# Public cloud high-speed interconnects
+
+:::{csv-table}
+:header: >
+: cloud, interconnect, instance availability, subnet management, deployment notes
+
+[Amazon Web Services](https://aws.amazon.com/), [Elastic Fabric Adapter (EFA)](https://aws.amazon.com/hpc/efa/), [Supported instance types](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types), Provided by cloud, **Not supported** <!-- [Manual setup documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html) -->
+[Microsoft Azure](https://portal.azure.com), [InfiniBand](https://learn.microsoft.com/en-us/azure/virtual-machines/setup-infiniband), [RDMA-capable instances](https://learn.microsoft.com/en-us/azure/virtual-machines/setup-infiniband#rdma-capable-instances), Provided by cloud, VMs in the same [availability set](https://learn.microsoft.com/en-us/azure/virtual-machines/availability-set-overview) have the same InfiniBand PKEY.<br><br>All units in a Juju application are deployed in the same availability set automatically.
+:::


### PR DESCRIPTION
Adds an explanation for high-speed interconnects/RDMA implementations, including general definitions and how Charmed-HPC enables RDMA use.

Adds a reference table for cloud interconnects and their status in Charmed-HPC. At the moment, Azure is the only supported cloud out of the box but I've also included some AWS details following investigative work into their EFA solution.