### PR TITLE
feat: add filesystem_info to the reference

### DIFF
--- a/reference/underlying-projects-and-dependencies.md
+++ b/reference/underlying-projects-and-dependencies.md
@@ -130,4 +130,5 @@ slurmctld, [Charm library](https://github.com/charmed-hpc/slurm-charms/blob/main
 [cos_agent](https://charmhub.io/integrations/cos_agent), [Charm library](https://charmhub.io/grafana-agent/libraries/cos_agent)
 [ldap](https://charmhub.io/integrations/ldap/), [Charm library](https://charmhub.io/glauth-k8s/libraries/ldap)
 [mysql_client](https://charmhub.io/integrations/mysql_client), [Charm library](https://charmhub.io/data-platform-libs/libraries/data_interfaces)
+[filesystem_info](https://charmhub.io/integrations/filesystem_info), [Charm library](https://charmhub.io/filesystem-client/libraries/filesystem_info)
 :::


### PR DESCRIPTION
https://github.com/canonical/charm-relation-interfaces/pull/217 was merged, so we can add the interface to our list of maintained projects and dependencies.