### PR TITLE
fix: add `--base` to `grafana-agent` deploy command

### DIFF
--- a/howto/manage/integrate-with-cos.md
+++ b/howto/manage/integrate-with-cos.md
@@ -50,7 +50,7 @@ First, within your `charmed-hpc` cloud, use `juju deploy`{l=shell} to deploy Gra
 on your cluster:
 
 :::{code-block} shell
-juju deploy --model charmed-hpc-controller:slurm grafana-agent
+juju deploy --model charmed-hpc-controller:slurm grafana-agent --base "ubuntu@24.04"
 :::
 
 ### Connect Charmed HPC to Grafana Agent


### PR DESCRIPTION
A minor fix to the COS integration instructions to include ` --base "ubuntu@24.04"` when deploying `grafana-agent`. If this is not included, the charm is deployed with `ubuntu@22.04` and gives a "bases must match" error when trying to integrate it with the `ubuntu@24.04` Slurm charms.