### PR TITLE
docs: add VM instance compatibility matrix

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -62,6 +62,14 @@ maas
 microsoft
 OpenStack
 
+# Cloud VM instance types
+Dasv
+Dv
+HB
+HBv
+NCasT
+NVadsA
+
 # Developer jargon/acronyms
 conf
 CUDA

--- a/index.md
+++ b/index.md
@@ -43,6 +43,7 @@ __Discussion and clarification__ of key topics
 __Technical information__
 
 - {ref}`reference-underlying-projects-and-dependencies`
+- {ref}`reference-compatibility-matrix`
 - {ref}`gres`
 - {ref}`reference-interconnects`
 - {ref}`reference-performance`

--- a/index.md
+++ b/index.md
@@ -43,12 +43,13 @@ __Discussion and clarification__ of key topics
 __Technical information__
 
 - {ref}`reference-underlying-projects-and-dependencies`
-- {ref}`reference-compatibility-matrix`
 - {ref}`gres`
 - {ref}`reference-interconnects`
 - {ref}`reference-performance`
 - {ref}`reference-monitoring`
+- {ref}`reference-vm-compatibility`
 <!-- - {ref}`reference-glossary` -->
+
 ```
 
 ````

--- a/reference/compatibility-matrix.md
+++ b/reference/compatibility-matrix.md
@@ -6,7 +6,7 @@ The tables below provide an overview of cloud instance types that have been test
 The compatibility key:
 
 * <span style="color:green">&#x2714; Compatible</span>: Fully compatible with all Charmed HPC features. No known issues.
-* <span style="color:orange">&#x25B3; Partial</span>: May be compatible with a subset of Charmed HPC features or have issues that can be worked around to allow for basic use.
+* <span style="color:orange">&#x25B3; Partial</span>: May be compatible with a subset of Charmed HPC features or may have issues that require work-arounds.
 * <span style="color:red">&#x2718; Incompatible</span>: Has issues that prevent even basic use.
 
 ## Microsoft Azure

--- a/reference/compatibility-matrix.md
+++ b/reference/compatibility-matrix.md
@@ -1,0 +1,74 @@
+(reference-compatibility-matrix)=
+# Compatibility Matrix
+
+The tables below provide an overview of cloud instance types that have been tested for compatibility with Charmed HPC revisions. Key:
+
+* <span style="color:green">&#x2714; Compatible</span>: Fully compatible with all Charmed HPC features. No known issues.
+* <span style="color:orange">&#x25B3; Partial</span>: May be compatible with a subset of Charmed HPC features or have issues that can be worked around to allow for basic use.
+* <span style="color:red">&#x2718; Incompatible</span>: Has issues that prevent even basic use.
+
+## Microsoft Azure
+
+### Charm: `sackd`
+
+**Revision:** 13
+
+:::{csv-table}
+:header: >
+: instance type, series, compatibility, notes
+:widths: 9, 5, 6, 9
+
+Standard_D2as_v6, [Dasv6](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dasv6-series), <span style="color:green">&#x2714; Compatible</span>, ""
+:::
+
+### Charm: `slurmctld`
+
+**Revision:** 95
+
+:::{csv-table}
+:header: >
+: instance type, series, compatibility, notes
+:widths: 9, 5, 6, 9
+
+Standard_D2as_v6, [Dasv6](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dasv6-series), <span style="color:green">&#x2714; Compatible</span>, ""
+:::
+
+### Charm: `slurmd`
+
+**Revision:** 116
+
+:::{csv-table}
+:header: >
+: instance type, series, compatibility, notes
+:widths: 9, 5, 6, 9
+
+Standard_HB120rs_v3, [HBv3](https://learn.microsoft.com/en-us/azure/virtual-machines/hbv3-series-overview), <span style="color:green">&#x2714; Compatible</span>, ""
+Standard_HB176rs_v4, [HBv4](https://learn.microsoft.com/en-us/azure/virtual-machines/hbv4-series-overview), <span style="color:green">&#x2714; Compatible</span>, ""
+Standard_NC24ads_A100_v4, [NC_A100_v4](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/nca100v4-series), <span style="color:green">&#x2714; Compatible</span>, ""
+Standard_NC4as_T4_v3, [NCasT4_v3](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/ncast4v3-series), <span style="color:green">&#x2714; Compatible</span>, ""
+Standard_NV6ads_A10_v5, [NVadsA10_v5](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/nvadsa10v5-series), <span style="color:red">&#x2718; Incompatible</span>, "GPU driver failures. See [#82](https://github.com/charmed-hpc/slurm-charms/issues/82)"
+:::
+
+### Charm: `slurmdbd`
+
+**Revision:** 87
+
+:::{csv-table}
+:header: >
+: instance type, series, compatibility, notes
+:widths: 9, 5, 6, 9
+
+Standard_D2as_v6, [Dasv6](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dasv6-series), <span style="color:green">&#x2714; Compatible</span>, ""
+:::
+
+### Charm: `slurmrestd`
+
+**Revision:** 89
+
+:::{csv-table}
+:header: >
+: instance type, series, compatibility, notes
+:widths: 9, 5, 6, 9
+
+Standard_D2as_v6, [Dasv6](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/general-purpose/dasv6-series), <span style="color:green">&#x2714; Compatible</span>, ""
+:::

--- a/reference/compatibility-matrix.md
+++ b/reference/compatibility-matrix.md
@@ -9,6 +9,8 @@ The tables below provide an overview of cloud instance types that have been test
 
 ## Microsoft Azure
 
+To decide on suitable VMs, it may be useful to refer to [Sizes for virtual machines in Azure](https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/overview). A typical Charmed HPC deployment will use a mix of high-performance and GPU-accelerated compute VMs for cluster compute nodes, and general purpose VMs for other node types.
+
 ### Charm: `sackd`
 
 **Revision:** 13

--- a/reference/compatibility-matrix.md
+++ b/reference/compatibility-matrix.md
@@ -7,7 +7,7 @@ The compatibility key:
 
 * <span style="color:green">&#x2714; Compatible</span>: Fully compatible with all Charmed HPC features. No known issues.
 * <span style="color:orange">&#x25B3; Partial</span>: May be compatible with a subset of Charmed HPC features or may have issues that require work-arounds.
-* <span style="color:red">&#x2718; Incompatible</span>: Has issues that prevent even basic use.
+* <span style="color:red">&#x2718; Incompatible</span>: Has issues that prevent all use-cases.
 
 ## Microsoft Azure
 

--- a/reference/compatibility-matrix.md
+++ b/reference/compatibility-matrix.md
@@ -1,7 +1,9 @@
 (reference-compatibility-matrix)=
 # Compatibility Matrix
 
-The tables below provide an overview of cloud instance types that have been tested for compatibility with Charmed HPC revisions. Key:
+The tables below provide an overview of cloud instance types that have been tested for compatibility with Charmed HPC revisions. Inclusion in a table indicates that the corresponding VM type has been tested; however, exclusion from the table simply indicates that the instance has not been tested thoroughly and may be compatible or incompatible with Charmed HPC. 
+
+The compatibility key:
 
 * <span style="color:green">&#x2714; Compatible</span>: Fully compatible with all Charmed HPC features. No known issues.
 * <span style="color:orange">&#x25B3; Partial</span>: May be compatible with a subset of Charmed HPC features or have issues that can be worked around to allow for basic use.

--- a/reference/index.md
+++ b/reference/index.md
@@ -7,6 +7,7 @@ Charmed HPC operates.
 ## General information
 
 - {ref}`reference-underlying-projects-and-dependencies`
+- {ref}`reference-compatibility-matrix`
 - {ref}`gres`
 - {ref}`reference-interconnects`
 - {ref}`reference-monitoring`
@@ -19,6 +20,7 @@ Charmed HPC operates.
 :hidden:
 
 Underlying projects and dependencies <underlying-projects-and-dependencies>
+compatibility-matrix
 gres/index
 interconnects/index
 monitoring/index

--- a/reference/index.md
+++ b/reference/index.md
@@ -7,11 +7,11 @@ Charmed HPC operates.
 ## General information
 
 - {ref}`reference-underlying-projects-and-dependencies`
-- {ref}`reference-compatibility-matrix`
 - {ref}`gres`
 - {ref}`reference-interconnects`
 - {ref}`reference-monitoring`
 - {ref}`reference-performance`
+- {ref}`reference-vm-compatibility`
 <!-- - {ref}`reference-glossary` -->
 
 ```{filtered-toctree}
@@ -20,11 +20,11 @@ Charmed HPC operates.
 :hidden:
 
 Underlying projects and dependencies <underlying-projects-and-dependencies>
-compatibility-matrix
 gres/index
 interconnects/index
 monitoring/index
 Performance <performance>
+vm-compatibility
 :draft:Glossary <glossary>
 
 ```

--- a/reference/vm-compatibility.md
+++ b/reference/vm-compatibility.md
@@ -1,12 +1,12 @@
-(reference-compatibility-matrix)=
-# Compatibility Matrix
+(reference-vm-compatibility)=
+# Virtual Machine Compatibility
 
-The tables below provide an overview of cloud instance types that have been tested for compatibility with Charmed HPC revisions. Inclusion in a table indicates that the corresponding VM type has been tested; however, exclusion from the table simply indicates that the instance has not been tested thoroughly and may be compatible or incompatible with Charmed HPC. 
+The tables below provide an overview of cloud instance types that have been tested for compatibility with Charmed HPC revisions. Inclusion in a table indicates that the corresponding VM type has been tested; however, exclusion from the table simply indicates that the instance has not been tested thoroughly and may be compatible or incompatible with Charmed HPC.
 
 The compatibility key:
 
 * <span style="color:green">&#x2714; Compatible</span>: Fully compatible with all Charmed HPC features. No known issues.
-* <span style="color:orange">&#x25B3; Partial</span>: May be compatible with a subset of Charmed HPC features or may have issues that require work-arounds.
+* <span style="color:orange">&#x25B3; Partial</span>: May be compatible with a subset of Charmed HPC features or may have issues that require workarounds.
 * <span style="color:red">&#x2718; Incompatible</span>: Has issues that prevent all use-cases.
 
 ## Microsoft Azure

--- a/reference/vm-compatibility.md
+++ b/reference/vm-compatibility.md
@@ -1,11 +1,11 @@
 (reference-vm-compatibility)=
 # Virtual machine compatibility
 
-The tables below provide an overview of cloud instance types that have been tested for compatibility with Charmed HPC revisions. Inclusion in a table indicates that the corresponding VM type has been tested; however, exclusion from the table simply indicates that the instance has not been tested thoroughly and may be compatible or incompatible with Charmed HPC.
+The tables below provide an overview of cloud instance types that have been tested for compatibility with Charmed HPC revisions. Inclusion in a table indicates that the corresponding VM type has been shown to work effectively; however this data is for informational purposes only and should not be construed as an official guarantee of full compatibility or comprehensive support. Exclusion from the table simply indicates that the instance has not been tested thoroughly and may be compatible or incompatible with Charmed HPC.
 
 The compatibility key:
 
-* <span style="color:green">&#x2714; Compatible</span>: Fully compatible with all Charmed HPC features. No known issues.
+* <span style="color:green">&#x2714; Compatible</span>: Compatible with all Charmed HPC features. No known issues.
 * <span style="color:orange">&#x25B3; Partial</span>: May be compatible with a subset of Charmed HPC features or may have issues that require workarounds.
 * <span style="color:red">&#x2718; Incompatible</span>: Has issues that prevent all use-cases.
 

--- a/reference/vm-compatibility.md
+++ b/reference/vm-compatibility.md
@@ -1,5 +1,5 @@
 (reference-vm-compatibility)=
-# Virtual Machine Compatibility
+# Virtual machine compatibility
 
 The tables below provide an overview of cloud instance types that have been tested for compatibility with Charmed HPC revisions. Inclusion in a table indicates that the corresponding VM type has been tested; however, exclusion from the table simply indicates that the instance has not been tested thoroughly and may be compatible or incompatible with Charmed HPC.
 


### PR DESCRIPTION
Adds a compatibility matrix reference page for VM instance types that have been used for testing Charmed HPC on Azure.

At the moment, this is mostly beneficial for the `slurmd` charm, as this has been tested on a few different combinations of instances to confirm RDMA and GPU compatibility. The remaining charms have been exclusively run on `Standard_D2as_v6` instances, Juju's default for Azure.