### PR TITLE
fix: update links to juju documentation is how-tos

### DIFF
--- a/howto/initialize-cloud-environment.md
+++ b/howto/initialize-cloud-environment.md
@@ -29,9 +29,9 @@ as a cloud.
 To initialize the cloud environment where you will deploy your Charmed HPC cluster,
 you will need:
 
-* Access to a [supported machine cloud](https://juju.is/docs/juju/juju-supported-clouds)
-* Access to a [supported Kubernetes cloud](https://juju.is/docs/juju/juju-supported-clouds)
-* The [Juju CLI client](https://juju.is/docs/juju/install-and-manage-the-client) installed on your machine
+* Access to a [supported machine cloud](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/cloud/list-of-supported-clouds/)
+* Access to a [supported Kubernetes cloud](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/cloud/list-of-supported-clouds/)
+* The [Juju CLI client](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-juju/) installed on your machine
 
 (howto-initialize-machine-cloud)=
 ## Initialize machine cloud

--- a/howto/setup/deploy-slurm.md
+++ b/howto/setup/deploy-slurm.md
@@ -14,7 +14,7 @@ The deployment, management, and operations of Slurm are controlled by the Slurm 
 To successfully deploy Slurm in your Charmed HPC cluster, you will at least need:
 
 - An [initialized cloud environment](#howto-initialize-cloud-environment).
-- The [Juju CLI client](https://juju.is/docs/juju/install-and-manage-the-client) installed on your machine.
+- The [Juju CLI client](https://canonical-juju.readthedocs-hosted.com/en/latest/user/howto/manage-juju/) installed on your machine.
 
 Once you have verified that you have met the prerequisites above, proceed to the instructions below.
 
@@ -22,14 +22,14 @@ Once you have verified that you have met the prerequisites above, proceed to the
 
 You have two options for deploying Slurm:
 
-1. Using the [Juju CLI client](https://juju.is/docs/juju/juju-client).
-2. Using the [Juju Terraform client](https://juju.is/docs/juju/terraform-juju-client).
+1. Using the [Juju CLI client](https://canonical-juju.readthedocs-hosted.com/en/latest/user/reference/juju-cli/).
+2. Using the [Juju Terraform client](https://canonical-terraform-provider-juju.readthedocs-hosted.com/en/latest/).
 
 If you want to use Terraform to deploy Slurm, see the
-[Install and manage the client (terraform juju)](https://juju.is/docs/juju/install-and-manage-the-client)
-how-to in the Juju documentation for additional requirements.
+[Manage `terraform-provider-juju`](https://canonical-terraform-provider-juju.readthedocs-hosted.com/en/latest/howto/manage-terraform-provider-juju/) how-to guide for additional
+requirements.
 
-If you are deploying Slurm on [LXD](https://ubuntu.com/lxd), see
+If you are deploying Slurm on [LXD](https://canonical.com/lxd), see
 [Deploying Slurm on LXD](#deploy-slurm-lxd) for more information on additional constraints
 that must be passed to Juju.
 


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
 * [x] I have insured that the documentation tests complete successfully.

## Summary of Changes

[//]: # (Please summarize your commits here. For any complex or contenious changes, please also provide justifications.)

Update links in "Initialize cloud environment" and "Deploy Slurm" how-to to point to the new Juju ReadTheDocs documentation rather than the old Discourse-based documentation.

#### Related Issues, PRs, and Discussions

Related to PR #51. The Juju Terraform documentation has been moved to its own ReadTheDocs site. 


