### PR TITLE
fix: add base when deploying sssd

### DIFF
--- a/howto/setup/deploy-glauth.md
+++ b/howto/setup/deploy-glauth.md
@@ -179,7 +179,7 @@ juju switch slurm
 Now use `juju deploy`{l=shell} to deploy SSSD:
 
 :::{code-block} shell
-juju deploy sssd --channel "edge"
+juju deploy sssd --base "ubuntu@24.04" --channel "edge"
 :::
 
 Now use `juju integrate`{l=shell} to integrate SSSD with the Slurm services


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
 * [x] I have insured that the documentation tests complete successfully.

## Summary of Changes

Fixes a small bug on the documentation related to deploying `sssd`, since it requires specifying the base to be compatible with the deployed slurmd and sackd nodes.