### PR TITLE
fix: use correct `juju` commands for deploying filesystem proxies

### DIFF
--- a/howto/setup/deploy-shared-filesystem.md
+++ b/howto/setup/deploy-shared-filesystem.md
@@ -100,10 +100,11 @@ After gathering all the required information, you can deploy the `nfs-server-pro
 expose the externally managed server inside a Juju model.
 
 :::{code-block} shell
-juju deploy nfs-server-proxy --config \
-    hostname=<server hostname> \
-    path=<exported path> \
-    port=<server port>
+juju deploy nfs-server-proxy \
+  --channel latest/edge \
+  --config hostname=<server hostname> \
+  --config path=<exported path> \
+  --config port=<server port>
 :::
 
 ::::::
@@ -194,11 +195,12 @@ Having collected all the required information, you can deploy the `cephfs-server
 expose the externally managed Ceph filesystem inside a Juju model.
 
 :::{code-block} shell
-juju deploy cephfs-server-proxy --config \
-    --config fsid=<value of $FSID> \
-    --config sharepoint=cephfs:/ \
-    --config monitor-hosts="<value of $HOST>" \
-    --config auth-info=fs-client:<value of $CLIENT_KEY>
+juju deploy cephfs-server-proxy \
+  --channel latest/edge \
+  --config fsid=<value of $FSID> \
+  --config sharepoint=cephfs:/ \
+  --config monitor-hosts="<value of $HOST>" \
+  --config auth-info=fs-client:<value of $CLIENT_KEY>
 :::
 
 ::::::
@@ -211,9 +213,10 @@ juju deploy cephfs-server-proxy --config \
 To add the `filesystem-client` charm, which mounts a shared filesystem to the cluster nodes:
 
 :::{code-block} shell
-juju deploy filesystem-client --channel latest/edge \
-    --config mountpoint='/scratch' \
-    --config noexec=true
+juju deploy filesystem-client \
+  --channel latest/edge \
+  --config mountpoint='/scratch' \
+  --config noexec=true
 :::
 
 The `mountpoint` configuration represents the path that the filesystem will be mounted onto.


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
 * [x] I have insured that the documentation tests complete successfully.

## Summary of Changes

[//]: # (Please summarize your commits here. For any complex or contenious changes, please also provide justifications.)

Update the shell commands in the filesystem howto to be correct. We must specify `--channel latest/edge` since by default Juju will only pull from `latest/stable`. Also `--config` is required for every configuration option you want to set at deploy as `--config` does not accept a variable amount of arguments from the command line.

Other changes:

- Reformat shell commands to follow styling convention of the rest of the documentation. 2 space indents for shell commands.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here - especially corresponding code PRs. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

N/A - noticed this issue as part of working with a community member.

