### PR TITLE
Update ReadTheDocs Urls for Charmed HPC

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Charmed HPC's documentation
 
-Do you want to contribute to Charmed HPC's documentation? You've come to
+Do you want to contribute to [Charmed HPC's documentation](https://canonical-charmed-hpc.readthedocs-hosted.com/latest/)? You've come to
 the right place then! __Here is how you can get involved.__
 
 Please take a moment to review this document so that the contribution

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Charmed HPC documentation
 
-[![Documentation Status](https://readthedocs.com/projects/canonical-charmed-hpc/badge/?version=latest)](https://canonical-charmed-hpc.readthedocs-hosted.com/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.com/projects/canonical-charmed-hpc/badge/?version=latest)](https://canonical-charmed-hpc.readthedocs-hosted.com/latest/)
 [![Matrix](https://img.shields.io/matrix/ubuntu-hpc%3Amatrix.org?logo=matrix&label=ubuntu-hpc)](https://matrix.to/#/#hpc:ubuntu.com)
 
 Charmed HPC's documentation 📑🔍


### PR DESCRIPTION
# Pre-submission checklist

 * [ ] I read and followed the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
 * [ ] I have insured that the documentation tests complete successfully.

## Summary of Changes

[//]: # (Please summarize your commits here. For any complex or contenious changes, please also provide justifications.)

The URl for Charmed HPC's documentation on ReadTheDocs has been updated to https://canonical-charmed-hpc.readthedocs-hosted.com/latest/, from https://canonical-charmed-hpc.readthedocs-hosted.com/en/latest/, and the link in the docs repo README needed to be updated. Also added a link to the RTD docs on the CONTRIBUTING.md page.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here - especially corresponding code PRs. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Various other Charmed HPC repos will have similar PRs to update appropriate URL locations.

