### PR TITLE
chore: add `mount_info` to the list of charm integrations

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -204,6 +204,7 @@ linkcheck_ignore = [
     "https://charmhub.io/topics/canonical-observability-stack/reference/best-practices#deploy-in-isolation",
     "https://jwt.io",
     "https://matrix.to/#/#hpc:ubuntu.com",
+    "https://charmhub.io/integrations/*" # Integrations page is very unstable sometimes
 ]
 
 

--- a/reference/underlying-projects-and-dependencies.md
+++ b/reference/underlying-projects-and-dependencies.md
@@ -133,4 +133,5 @@ slurmctld, [Charm library](https://github.com/charmed-hpc/slurm-charms/blob/main
 [ldap](https://charmhub.io/integrations/ldap/), [Charm library](https://charmhub.io/glauth-k8s/libraries/ldap)
 [mysql_client](https://charmhub.io/integrations/mysql_client), [Charm library](https://charmhub.io/data-platform-libs/libraries/data_interfaces)
 [filesystem_info](https://charmhub.io/integrations/filesystem_info), [Charm library](https://charmhub.io/filesystem-client/libraries/filesystem_info)
+[mount_info](https://charmhub.io/integrations/mount_info), [Charm library](https://charmhub.io/filesystem-client/libraries/mount_info)
 :::


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
 * [x] I have insured that the documentation tests complete successfully.

## Summary of Changes

Adds an entry for the new `mount_info` integration in the reference.