### PR TITLE
feat: add Apptainer how-tos

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -21,6 +21,7 @@ Apptainer
 catalogue
 Dockerhub
 Fortran
+fortran
 glauth
 GLAuth
 GLAuth's

--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -17,7 +17,10 @@ UCX
 
 # Charm/application/service names
 alertmanager
+Apptainer
 catalogue
+Dockerhub
+Fortran
 glauth
 GLAuth
 GLAuth's
@@ -61,6 +64,7 @@ GCP
 GCP's
 GKE
 gcloud
+Valkey
 
 # CLI commands
 hostname

--- a/howto/index.md
+++ b/howto/index.md
@@ -26,6 +26,7 @@ taking you through the setup of your own Charmed HPC cluster.
 The how-to guides in this section show you how to integrate with optional services and perform common management tasks after you have
 deployed Charmed HPC.
 
+- {ref}`howto-manage-integrate-with-apptainer`
 - {ref}`howto-manage-integrate-with-cos`
 - {ref}`howto-manage-integrate-with-influxdb`
 - {ref}`howto-manage-slurm`
@@ -44,5 +45,6 @@ It is important to clean up resources that are no longer necessary, especially i
 Initialize cloud environment <initialize-cloud-environment>
 setup/index
 manage/index
+use/index
 Clean up cloud resources <cleanup-cloud-resources>
 :::

--- a/howto/manage/index.md
+++ b/howto/manage/index.md
@@ -12,6 +12,7 @@ that are responsible for managing cluster deployments.
 These how-to guides provide instructions for integrating Charmed HPC with other
 applications to extend the functionality of your cluster.
 
+- {ref}`howto-manage-integrate-with-apptainer`
 - {ref}`howto-manage-integrate-with-cos`
 - {ref}`howto-manage-integrate-with-influxdb`
 
@@ -26,6 +27,7 @@ These how-to guides provide instructions for configuring an existing Charmed HPC
 :maxdepth: 1
 :hidden:
 
+Integrate with Apptainer <integrate-with-apptainer>
 Integrate with COS <integrate-with-cos>
 Integrate with InfluxDB <integrate-with-influxdb>
 Manage Slurm <manage-slurm>

--- a/howto/manage/integrate-with-apptainer.md
+++ b/howto/manage/integrate-with-apptainer.md
@@ -1,0 +1,71 @@
+---
+relatedlinks: "[Apptainer&#32;website](https://apptainer.org), [Apptainer&#32;(Charmhub)](https://charmhub.io/apptainer), [Apptainer&#32;charm&#32;repository](https://github.com/charmed-hpc/apptainer-operator)"
+---
+
+(howto-manage-integrate-with-apptainer)=
+# Integrate with Apptainer
+
+Charmed HPC can integrate with Apptainer to enable container workload scheduling with Slurm.
+
+This guide explains how to enable container workload scheduling by
+deploying and integrating Apptainer with Charmed HPC.
+
+:::{hint}
+If you're unfamiliar with operating Apptainer, see the [Apptainer admin quick start](https://apptainer.org/docs/admin/latest/admin_quickstart.html)
+guide for a high-level introduction to administering Apptainer.
+:::
+
+## Prerequisites
+
+- A [deployed Slurm cluster](#howto-setup-deploy-slurm).
+
+## Deploy and integrate Apptainer
+
+First, in the same model holding your Slurm deployment, deploy Apptainer with `juju deploy`{l=shell}:
+
+:::{code-block} shell
+juju deploy apptainer
+:::
+
+Now, with `juju integrate`{l=shell}, integrate Apptainer with the Slurm:
+
+:::{code-block} shell
+juju integrate apptainer sackd
+juju integrate apptainer slurmd
+juju integrate apptainer slurmctld
+:::
+
+Apptainer will be installed on all the `sackd` and `slurmd` units, and will share its configuration
+with the Slurm controller, `slurmctld`.
+
+## Test that Apptainer is integrated with Slurm
+
+Submit a test job with `juju exec`{l=shell}:
+
+:::{code-block} shell
+juju exec -u sackd/0 -- \
+  srun --partition slurmd --container=docker://ubuntu:jammy \
+  cat /etc/os-release | \
+  grep ^VERSION
+:::
+
+If Apptainer has been successfully integrated with Slurm, the output of your test
+job should be similar to the following:
+
+:::{terminal}
+:input: juju exec -u sackd/0 -- srun --partition slurmd --container=docker://ubuntu:jammy cat /etc/os-release | grep ^VERSION
+INFO:    Converting OCI blobs to SIF format
+INFO:    Starting build...
+INFO:    Fetching OCI image...
+INFO:    Extracting OCI image...
+INFO:    Inserting Apptainer configuration...
+INFO:    Creating SIF file...
+VERSION_ID="22.04"
+VERSION="22.04.5 LTS (Jammy Jellyfish)"
+VERSION_CODENAME=jammy
+:::
+
+## Next steps
+
+You can now use Apptainer to run workloads and build container images on your Charmed HPC cluster.
+Explore the {ref}`howto-use-apptainer` how-to for more information on using Apptainer on your Charmed HPC cluster.

--- a/howto/manage/integrate-with-apptainer.md
+++ b/howto/manage/integrate-with-apptainer.md
@@ -1,18 +1,19 @@
 ---
-relatedlinks: "[Apptainer&#32;website](https://apptainer.org), [Apptainer&#32;(Charmhub)](https://charmhub.io/apptainer), [Apptainer&#32;charm&#32;repository](https://github.com/charmed-hpc/apptainer-operator)"
+relatedlinks: "[Apptainer&#32;admin&#32;documentation](https://apptainer.org/docs/admin/latest/), [Apptainer&#32;(Charmhub)](https://charmhub.io/apptainer), [Apptainer&#32;charm&#32;repository](https://github.com/charmed-hpc/apptainer-operator)"
 ---
 
 (howto-manage-integrate-with-apptainer)=
 # Integrate with Apptainer
 
 Charmed HPC can integrate with Apptainer to enable container workload scheduling with Slurm.
+This guide explains how to enable container workload scheduling by deploying and integrating
+Apptainer with Charmed HPC.
 
-This guide explains how to enable container workload scheduling by
-deploying and integrating Apptainer with Charmed HPC.
+:::{admonition} New to Apptainer?
+:class: note
 
-:::{hint}
-If you're unfamiliar with operating Apptainer, see the [Apptainer admin quick start](https://apptainer.org/docs/admin/latest/admin_quickstart.html)
-guide for a high-level introduction to administering Apptainer.
+If you're unfamiliar with operating Apptainer installations, see the [Apptainer admin quick start guide](https://apptainer.org/docs/admin/latest/admin_quickstart.html)
+for a high-level introduction to administering Apptainer.
 :::
 
 ## Prerequisites
@@ -23,16 +24,38 @@ guide for a high-level introduction to administering Apptainer.
 
 First, in the same model holding your Slurm deployment, deploy Apptainer with `juju deploy`{l=shell}:
 
-:::{code-block} shell
-juju deploy apptainer
+:::{terminal}
+:copy:
+:input: juju deploy apptainer
 :::
 
-Now, with `juju integrate`{l=shell}, integrate Apptainer with the Slurm:
+::::{dropdown} Tip: Determining the current Juju model
+You can use `juju switch`{l=shell} to determine the current model you're operating on:
 
-:::{code-block} shell
-juju integrate apptainer sackd
-juju integrate apptainer slurmd
-juju integrate apptainer slurmctld
+:::{terminal}
+:copy:
+:input: juju switch
+charmed-hpc-controller:admin/slurm
+:::
+
+<!--
+  This raw `<br>` element is here because :terminal: directive does not add padding to the
+  bottom of the rendered block that the text is too close
+-->
+<br>
+
+The output above shows that we're operating on the `slurm` model as the `admin` user
+through the Juju controller `charmed-hpc-controller`.
+::::
+
+Now integrate Apptainer with Slurm using `juju integrate`{l=shell}:
+
+:::{terminal}
+:copy:
+:input: juju integrate apptainer sackd
+
+:input: juju integrate apptainer slurmd
+:input: juju integrate apptainer slurmctld
 :::
 
 Apptainer will be installed on all the `sackd` and `slurmd` units, and will share its configuration
@@ -40,20 +63,12 @@ with the Slurm controller, `slurmctld`.
 
 ## Test that Apptainer is integrated with Slurm
 
-Submit a test job with `juju exec`{l=shell}:
-
-:::{code-block} shell
-juju exec -u sackd/0 -- \
-  srun --partition slurmd --container=docker://ubuntu:jammy \
-  cat /etc/os-release | \
-  grep ^VERSION
-:::
-
-If Apptainer has been successfully integrated with Slurm, the output of your test
-job should be similar to the following:
+Submit a test job with `juju exec`{l=text}. If Apptainer has been successfully integrated with
+Slurm, the output of your test job will be similar to the following:
 
 :::{terminal}
-:input: juju exec -u sackd/0 -- srun --partition slurmd --container=docker://ubuntu:jammy cat /etc/os-release | grep ^VERSION
+:copy:
+:input: juju exec -u sackd/0 -- srun --partition slurmd --container=docker://ubuntu:22.04 cat /etc/os-release | grep ^VERSION
 INFO:    Converting OCI blobs to SIF format
 INFO:    Starting build...
 INFO:    Fetching OCI image...

--- a/howto/use/index.md
+++ b/howto/use/index.md
@@ -1,0 +1,22 @@
+# Use
+
+See the how-to guides in this section for using Charmed HPC after deployment.
+
+:::{note}
+The how-to guides in this section are users performing tasks such as submitting
+jobs or developing workloads, but are not responsible for managing cluster deployments.
+:::
+
+## Run workloads on the cluster
+
+These how-to guides provide instructions for running different types of workloads on Charmed HPC.
+
+- {ref}`howto-use-apptainer`
+
+:::{toctree}
+:titlesonly:
+:maxdepth: 1
+:hidden:
+
+Use Apptainer <use-apptainer>
+:::

--- a/howto/use/index.md
+++ b/howto/use/index.md
@@ -3,8 +3,8 @@
 See the how-to guides in this section for using Charmed HPC after deployment.
 
 :::{note}
-The how-to guides in this section are users performing tasks such as submitting
-jobs or developing workloads, but are not responsible for managing cluster deployments.
+The how-to guides in this section are for users who are performing tasks such as submitting
+jobs or developing workloads, but are not necessarily responsible for managing cluster deployments.
 :::
 
 ## Run workloads on the cluster

--- a/howto/use/use-apptainer.md
+++ b/howto/use/use-apptainer.md
@@ -1,0 +1,223 @@
+(howto-use-apptainer)=
+# Use Apptainer
+
+Apptainer can be used as a container runtime environment on Charmed HPC for running
+containerized workloads. This guide explains how to use different features of Apptainer
+on Charmed HPC.
+
+:::{hint}
+If you're unfamiliar with using Apptainer, see the [Apptainer user quick start](https://apptainer.org/docs/user/latest/quick_start.html)
+guide for a high-level introduction to using Apptainer.
+:::
+
+## Prerequisites
+
+To successfully use Apptainer on your Charmed HPC cluster, you will at least need:
+
+- A [deployed Slurm cluster](#howto-setup-deploy-slurm).
+- An [active Apptainer integration](#howto-manage-integrate-with-apptainer).
+
+Once you have verified that Apptainer is integrated with your Charmed HPC, refer
+to the sections below for the different ways that you can use Apptainer on Charmed HPC.
+
+## Create a container image
+
+Apptainer can create container images on your cluster that can then be used within
+your workloads. The sections below demonstrate the different ways Apptainer can create
+container images on your Charmed HPC cluster.
+
+### Using a pre-existing container image from a public container registry
+
+Apptainer can pull pre-existing container images from public container registries.
+For example, to pull a Valkey container image from Dockerhub and start a local
+Valkey service on your cluster:
+
+:::{terminal}
+:copy:
+:host: login
+:input: apptainer pull valkey.sif docker://ubuntu/valkey:7.2.10-24.04_stable
+
+:input: apptainer overlay create --size 1024 valkey.img
+:input: apptainer instance run --overlay valkey.img valkey.sif valkey
+INFO:    instance started successfully
+:input: apptainer exec instance://valkey valkey-cli ping
+PONG
+:::
+
+Use `apptainer help pull`{l=text} to see the full list of public container registries
+Apptainer can pull container images from.
+
+### Building your own custom container image
+
+Apptainer can build container images using instructions from a container definition file.
+For example, to build an Ubuntu 24.04 LTS-based container image with the `gfortran` compiler
+pre-installed, create a container definition file with `cat`{l=shell}:
+
+:::{code-block} shell
+cat << 'EOF' > workload.def
+bootstrap: docker
+from: ubuntu:24.04
+
+%post
+    apt-get -y update
+    apt-get -y install gfortran
+
+%test
+    gfortran --version
+    exit 0
+EOF
+:::
+
+Now use `apptainer build`{l=shell} to build the container image:
+
+:::{terminal}
+:copy:
+:host: login
+:input: apptainer build workload.sif workload.def
+:::
+
+The built container image can now be used to compile and run Fortran workloads. For
+example, use `cat`{l=shell} to create a simple Fortran program the prints _Hello world!_
+
+:::{code-block} shell
+cat << 'EOF' > hello.90
+PROGRAM hello_world
+  IMPLICIT NONE
+  PRINT *, "Hello world!"
+END PROGRAM hello_world
+EOF
+:::
+
+Now use the built container to compile and run the Fortran program:
+
+:::{terminal}
+:copy:
+:host: login
+:input: apptainer exec workload.sif gfortran --output hello hello.f90
+
+:input: apptainer exec workload.sif ./hello
+Hello world!
+:::
+
+:::{warning}
+Check with your cluster administrator before attempting to build container images
+on your Charmed HPC cluster. Each site has different policies about whether you
+can build container images directly on your cluster, and some disallow
+building container images on specific cluster resources such as login nodes.
+:::
+
+## Provide your workload's runtime environment
+
+Apptainer can provide the runtime environment for your workloads.
+The sections below demonstrate the different ways Apptainer can provide
+your workload's runtime environment.
+
+### Using the `apptainer`{l=shell} command directly in your workload
+
+Declare in your batch script the partition you want your workload to run within and call the
+`apptainer`{l=shell} command from directly within your script. For example, to select `compute`
+as the partition your workload will run within, and run some Python code using a containerized
+Python 3.13 interpreter, create a batch script with `cat`{l=shell}:
+
+:::{code-block} shell
+cat << 'EOF' > job.batch
+#!/usr/bin/env bash
+#SBATCH --partition compute
+#SBATCH --output %j.out
+
+apptainer pull python-3.13.sif docker://ubuntu/python:3.13-25.04
+apptainer --silent exec python-3.13.sif \
+  python3 -c 'import sys; print(f"Hello from Python {sys.version}!")'
+EOF
+:::
+
+Now submit your created batch script to Slurm with `sbatch`{l=shell}:
+
+:::{terminal}
+:copy:
+:host: login
+:input: sbatch job.batch
+Submitted batch job 1
+:::
+
+Use `cat`{l=shell} to review the results of your batch script after it completes:
+
+:::{terminal}
+:copy:
+:host: login
+:input: cat 1.out
+Hello from Python 3.13.3 (main, Aug 14 2025, 11:53:40) [GCC 14.2.0]!
+:::
+
+:::{important}
+Remember your job identification number after submitting your batch script
+with `sbatch`{l=shell}. It may be different from the example output above.
+:::
+
+[//]: # (TODO: Uncomment once https://github.com/charmed-hpc/slurm-charms/issues/143 is fixed.)
+<!--
+### Using the `--container` flag with `sbatch`{l=shell}
+
+Declare in your batch script's front matter both the partition you want your workload to run within
+and the container that will provide the runtime environment of your workload. For example, to create
+a batch script with `compute ` selected as the partition your workload will run
+within, and use a container with Python 3.13 pre-installed as the runtime environment:
+
+:::{code-block} shell
+cat << 'EOF' > my-job.batch
+#!/usr/bin/env bash
+#SBATCH --partition compute
+#SBATCH --container docker://ubuntu/python:3.13-25.04
+#SBATCH --output stdout-%j.log
+
+python3 --version
+EOF
+:::
+
+Now submit your batch script using the `sbatch`{l=shell} command:
+
+:::{terminal}
+:copy:
+:host: login
+:input: sbatch my-job.batch
+:::
+-->
+
+### Using the `--container` flag with `srun`{l=shell}
+
+Declare both the partition you want your workload to run within and the container that
+will provide the runtime environment of your workload. For example, to select `compute`
+as the partition your workload will run within, and use an Ubuntu 22.04 LTS container
+as the runtime environment:
+
+:::{terminal}
+:copy:
+:host: login
+:input: PARTITION=slurmd
+
+:input: CONTAINER=docker://ubuntu:22.04
+:::
+
+Now run your workload with `srun`{l=shell}:
+
+:::{terminal}
+:copy:
+:host: login
+:input: srun --partition $PARTITION --container $CONTAINER cat /etc/os-release | grep ^VERSION
+INFO:    Converting OCI blobs to SIF format
+INFO:    Starting build...
+INFO:    Fetching OCI image...
+INFO:    Extracting OCI image...
+INFO:    Inserting Apptainer configuration...
+INFO:    Creating SIF file...
+VERSION_ID="22.04"
+VERSION="22.04.5 LTS (Jammy Jellyfish)"
+VERSION_CODENAME=jammy
+:::
+
+
+
+
+
+
+

--- a/howto/use/use-apptainer.md
+++ b/howto/use/use-apptainer.md
@@ -51,10 +51,10 @@ Apptainer can pull container images from.
 
 Apptainer can build container images using instructions from a container definition file.
 For example, to build an Ubuntu 24.04 LTS-based container image with the `gfortran` compiler
-pre-installed, create a container definition file with `cat`{l=shell}:
+pre-installed, create the container definition file _workload.def_:
 
 :::{code-block} shell
-cat << 'EOF' > workload.def
+:caption: workload.def
 bootstrap: docker
 from: ubuntu:24.04
 
@@ -65,7 +65,6 @@ from: ubuntu:24.04
 %test
     gfortran --version
     exit 0
-EOF
 :::
 
 Now use `apptainer build`{l=shell} to build the container image:
@@ -77,18 +76,17 @@ Now use `apptainer build`{l=shell} to build the container image:
 :::
 
 The built container image can now be used to compile and run Fortran workloads. For
-example, use `cat`{l=shell} to create a simple Fortran program the prints _Hello world!_
+example, create a simple Fortran program the prints "Hello world!" in the file _hello.f90_:
 
-:::{code-block} shell
-cat << 'EOF' > hello.90
+:::{code-block} fortran
+:caption: hello.f90
 PROGRAM hello_world
   IMPLICIT NONE
   PRINT *, "Hello world!"
 END PROGRAM hello_world
-EOF
 :::
 
-Now use the built container to compile and run the Fortran program:
+Now use the built container to compile and run your Fortran program:
 
 :::{terminal}
 :copy:
@@ -117,10 +115,10 @@ your workload's runtime environment.
 Declare in your batch script the partition you want your workload to run within and call the
 `apptainer`{l=shell} command from directly within your script. For example, to select `compute`
 as the partition your workload will run within, and run some Python code using a containerized
-Python 3.13 interpreter, create a batch script with `cat`{l=shell}:
+Python 3.13 interpreter, create the batch script _job.batch_:
 
 :::{code-block} shell
-cat << 'EOF' > job.batch
+:caption: job.batch
 #!/usr/bin/env bash
 #SBATCH --partition compute
 #SBATCH --output %j.out
@@ -128,10 +126,9 @@ cat << 'EOF' > job.batch
 apptainer pull python-3.13.sif docker://ubuntu/python:3.13-25.04
 apptainer --silent exec python-3.13.sif \
   python3 -c 'import sys; print(f"Hello from Python {sys.version}!")'
-EOF
 :::
 
-Now submit your created batch script to Slurm with `sbatch`{l=shell}:
+Now submit the _job.batch_ script to Slurm with `sbatch`{l=shell}:
 
 :::{terminal}
 :copy:
@@ -140,7 +137,7 @@ Now submit your created batch script to Slurm with `sbatch`{l=shell}:
 Submitted batch job 1
 :::
 
-Use `cat`{l=shell} to review the results of your batch script after it completes:
+Use `cat`{l=shell} to view the results of your workload after it completes:
 
 :::{terminal}
 :copy:
@@ -164,14 +161,12 @@ a batch script with `compute ` selected as the partition your workload will run
 within, and use a container with Python 3.13 pre-installed as the runtime environment:
 
 :::{code-block} shell
-cat << 'EOF' > my-job.batch
 #!/usr/bin/env bash
 #SBATCH --partition compute
 #SBATCH --container docker://ubuntu/python:3.13-25.04
 #SBATCH --output stdout-%j.log
 
 python3 --version
-EOF
 :::
 
 Now submit your batch script using the `sbatch`{l=shell} command:

--- a/howto/use/use-apptainer.md
+++ b/howto/use/use-apptainer.md
@@ -51,6 +51,9 @@ INFO:    instance started successfully
 PONG
 :::
 
+Use `apptainer help pull`{l=text} to see the full list of public container registries
+Apptainer can pull container images from.
+
 ### Building your own custom container image
 
 :::{admonition} Before attempting to build your own container images
@@ -110,6 +113,13 @@ Now use the built container to compile and run your Fortran program:
 Hello world!
 :::
 
+:::{warning}
+Check with your cluster administrator before attempting to build container images
+on your Charmed HPC cluster. Each site has different policies about whether you
+can build container images directly on your cluster, and some disallow
+building container images on specific cluster resources such as login nodes.
+:::
+
 ## Provide your workload's runtime environment
 
 Apptainer can provide the runtime environment for your workloads.
@@ -118,10 +128,11 @@ your workload's runtime environment.
 
 ### Using the `apptainer`{l=shell} command directly in your workload
 
-Declare in your batch script the partition you want your workload to run within and call the
-`apptainer`{l=shell} command from directly within your batch script. For example, create the file
-_job.batch_, set `compute` as the partition your workload will run within, and run some
-Python code using a containerized Python 3.13 interpreter:
+The `apptainer`{l=shell} command can be called directly in scripts to perform operations
+inside a container instance. First, declare in your batch script the partition you want your
+workload to run within and call the `apptainer`{l=shell} command from directly within your script.
+For example, to select `compute` as the partition your workload will run within, and run some
+Python code using a containerized Python 3.13 interpreter, create the batch script _job.batch_:
 
 :::{code-block} shell
 :caption: job.batch
@@ -181,10 +192,11 @@ Now submit your batch script using the `sbatch`{l=shell} command:
 
 ### Using the `--container` flag with `srun`{l=shell}
 
-Declare both the partition you want your workload to run within and the container that
-will provide the runtime environment of your workload. For example, to select `compute`
-as the partition your workload will run within, and use an Ubuntu 22.04 LTS container
-as the runtime environment:
+Jobs submitted to Slurm with `srun`{l=shell} can be run inside a container instance using Apptainer.
+First, declare both the partition you want your workload to run within and the container image
+that will be used by Apptainer to provide the runtime environment of your workload.
+For example, to select `compute` as the partition your workload will run within,
+and use an Ubuntu 22.04 LTS container image as the runtime environment:
 
 :::{terminal}
 :copy:
@@ -210,10 +222,3 @@ VERSION_ID="22.04"
 VERSION="22.04.5 LTS (Jammy Jellyfish)"
 VERSION_CODENAME=jammy
 :::
-
-
-
-
-
-
-


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
 * [x] I have ensured that the documentation tests complete successfully.

## Summary of Changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds two new documentations pages:

1. Integrate with Apptainer
2. Use Apptainer

The "Integrate with Apptainer" how-to focuses on integrating Apptainer with the Slurm charms after they have been deployed, and the "Use Apptainer" how-to focuses on the different ways that a user can leverage Apptainer within Charmed HPC such as building custom images or running workloads.

### Things to note

1. There's currently a commented out section in the "Use Apptainer" how-to because it's related to bug https://github.com/charmed-hpc/slurm-charms/issues/143. Once I fix this bug, I'll uncomment this part of the how-to because it's quite useful.
2. Eventually, we might also want a "Manage Apptainer" how-to that goes through the available configurations that someone can set for Apptainer, but we would need to build that functionality out first. I'm concerned that eventually "Integrate with ..." and "Manage ..." will start competing with each other in the `Manage` category, so we might want to look into adding a separate `Integrate` category. 

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here - especially corresponding code PRs. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

This PR is related to our ongoing work to integrate Apptainer into Charmed HPC.

