### PR TITLE
fix: correct formatting of terminal blocks in COS howto

### DIFF
--- a/howto/manage/integrate-with-cos.md
+++ b/howto/manage/integrate-with-cos.md
@@ -50,7 +50,8 @@ First, within your `charmed-hpc` cloud, use `juju deploy`{l=shell} to deploy Gra
 on your cluster:
 
 :::{code-block} shell
-juju deploy --model charmed-hpc-controller:slurm grafana-agent --base "ubuntu@24.04"
+juju deploy grafana-agent --model charmed-hpc-controller:slurm \
+  --base "ubuntu@24.04"
 :::
 
 ### Connect Charmed HPC to Grafana Agent
@@ -80,8 +81,8 @@ juju show-unit --model cos-controller:cos catalogue/0 --format json | \
 The piped output of the `juju show-unit`{l=shell} command should be similar to the following:
 
 :::{terminal}
-:input: juju show-unit --model cos-controller:cos catalogue/0 --format json | \
-  jq '.[]."relation-info".[]."application-data".url | select (. != null)'
+:copy:
+:input: juju show-unit --model cos-controller:cos catalogue/0 --format json | jq '.[]."relation-info".[]."application-data".url | select (. != null)'
 
 "http://10.190.89.230/cos-grafana"
 "http://10.190.89.230/cos-prometheus-0"
@@ -105,8 +106,8 @@ If the output of `juju exec`{l=shell} looks similar to the success message below
 means that your `charmed-hpc` cloud can successfully contact your COS deployment:
 
 :::{terminal}
-:input: juju exec --unit grafana-agent/0 \
-  "curl -s http://10.190.89.230/cos-prometheus-0/api/v1/status/runtimeinfo"
+:copy:
+:input: juju exec --unit grafana-agent/0 -- curl -s http://10.190.89.230/cos-prometheus-0/api/v1/status/runtimeinfo
 
 {"status":"success","data":{"startTime":"2025-02-06T19:09:05.141616388Z","CWD":"/","reloadConfigSuccess":true,"lastConfigTime":"2025-02-06T19:10:36Z","corruptionCount":0,"goroutineCount":56,"GOMAXPROCS":8,"GOMEMLIMIT":9223372036854775807,"GOGC":"","GODEBUG":"","storageRetention":"15d or 819MiB204KiB819B"}}
 :::


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
 * [x] I have ensured that the documentation tests complete successfully.

## Summary of Changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR fixes the terminal formatting on the COS howto. Longer instructions were not wrapping to the next line, so additional/piped commands looked like they were a part of the terminal output rather than as part of the command the user had to execute.

On top of these fixes, I also enabled the `:copy:` directive so that users can copy the command verbatim. Eventually we'll want to see if we just want to go with the terminal blocks rather than have a code block followed by a terminal block - duplicate information being provided by two separate blocks colocated together - but we can discuss this more at the engineering sprint. I'd want the experience of command wrapping to be better with the `:terminal:` directive, but this might be a feature we have to add ourselves.


#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here - especially corresponding code PRs. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

This PR fixes incorrect terminal formatting that was breaking the readability of our documentation.

