### PR TITLE
fix: correct busted link checks

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -16,6 +16,7 @@ RESource
 UCX
 
 # Charm/application/service names
+apptainer
 alertmanager
 catalogue
 glauth
@@ -87,6 +88,7 @@ ip
 JWT
 libs
 MiB
+oci
 PCIe
 proxying
 PyPI

--- a/howto/setup/deploy-shared-filesystem.md
+++ b/howto/setup/deploy-shared-filesystem.md
@@ -21,7 +21,7 @@ cloud managed NFS server on the [`charmed-hpc-terraform`][hpc-tf] repository, wi
 ## Deploy an external filesystem server
 
 External servers that provide a shared filesystem cannot be integrated directly. Instead,
-we can use a [proxy charm](https://documentation.ubuntu.com/juju/latest/reference/charm/index.html#proxy) in order to expose
+we can use a [proxy charm](https://documentation.ubuntu.com/juju/latest/reference/charm/#proxy-charm) in order to expose
 the required information to applications managed by Juju.
 
 :::::::{tab-set}
@@ -226,7 +226,7 @@ juju deploy filesystem-client \
 
 The `mountpoint` configuration represents the path that the filesystem will be mounted onto.
 
-`filesystem-client` is a [subordinate charm](https://documentation.ubuntu.com/juju/latest/reference/relation/index.html#subordinate)
+`filesystem-client` is a [subordinate charm](https://documentation.ubuntu.com/juju/latest/reference/charm/#subordinate-charm)
 that can automatically mount any shared filesystems for the application related with it.
 In this case, we will relate it to the `slurmd` application in order to have a shared storage between
 all the compute nodes in the cluster:

--- a/reference/underlying-projects-and-dependencies.md
+++ b/reference/underlying-projects-and-dependencies.md
@@ -21,6 +21,7 @@ Core projects are projects that are maintained directly as part of Charmed HPC.
 slurm-charms, [Source](https://github.com/charmed-hpc/slurm-charms), [Issue tracker](https://github.com/charmed-hpc/slurm-charms/issues)
 filesystem-charms, [Source](https://github.com/charmed-hpc/filesystem-charms), [Issue tracker](https://github.com/charmed-hpc/filesystem-charms/issues)
 sssd-operator, [Source](https://github.com/canonical/sssd-operator), [Issue tracker](https://github.com/canonical/sssd-operator/issues)
+apptainer-operator, [Source](https://github.com/charmed-hpc/apptainer-operator), [Issue tracker](https://github.com/charmed-hpc/apptainer-operator/issues)
 slurmutils, [Source](https://github.com/charmed-hpc/slurmutils), [Issue tracker](https://github.com/charmed-hpc/slurmutils/issues)
 hpc-libs, [Source](https://github.com/charmed-hpc/hpc-libs), [Issue tracker](https://github.com/charmed-hpc/hpc-libs/issues)
 charmed-hpc-terraform, [Source](https://github.com/charmed-hpc/charmed-hpc-terraform), [Issue tracker](https://github.com/charmed-hpc/charmed-hpc-terraform/issues)
@@ -92,6 +93,7 @@ A charm does not have any modifiable configuration options or runnable actions i
 [nfs-server-proxy](https://charmhub.io/nfs-server-proxy), [Options](https://charmhub.io/nfs-server-proxy/configurations)
 [cephfs-server-proxy](https://charmhub.io/cephfs-server-proxy), [Options](https://charmhub.io/cephfs-server-proxy/configurations)
 [sssd](https://charmhub.io/sssd)
+[apptainer](https://charmhub.io/apptainer), , [Actions](https://charmhub.io/apptainer/actions)
 [grafana-agent](https://charmhub.io/grafana-agent), [Options](https://charmhub.io/grafana-agent/configurations)
 [mysql](https://charmhub.io/mysql), [Options](https://charmhub.io/mysql/configurations), [Actions](https://charmhub.io/mysql/actions)
 [mysql-router](https://charmhub.io/mysql-router), [Options](https://charmhub.io/mysql-router/configurations), [Actions](https://charmhub.io/mysql-router/actions)
@@ -124,11 +126,12 @@ Charmed HPC uses integrations to dictate how charmed applications communicate wi
 : integration, interface implementation
 :widths: 15, 10
 
-[sackd](https://charmhub.io/integrations/sackd), [Charm library](https://github.com/charmed-hpc/slurm-charms/blob/main/charms/slurmctld/src/interface_sackd.py)
-slurmctld, [Charm library](https://github.com/charmed-hpc/slurm-charms/blob/main/charms/slurmd/src/interface_slurmctld.py)
-[slurmd](https://charmhub.io/integrations/slurmd), [Charm library](https://github.com/charmed-hpc/slurm-charms/blob/main/charms/slurmctld/src/interface_slurmd.py)
-[slurmdbd](https://charmhub.io/integrations/slurmdbd), [Charm library](https://github.com/charmed-hpc/slurm-charms/blob/main/charms/slurmctld/src/interface_slurmdbd.py)
-[slurmrestd](https://charmhub.io/integrations/slurmrestd), [Charm library](https://github.com/charmed-hpc/slurm-charms/blob/main/charms/slurmctld/src/interface_slurmrestd.py)
+[sackd](https://charmhub.io/integrations/sackd), [Charm library](https://github.com/charmed-hpc/hpc-libs/blob/main/src/hpc_libs/interfaces/slurm/sackd.py)
+slurmctld, [Charm library](https://github.com/charmed-hpc/hpc-libs/blob/main/src/hpc_libs/interfaces/slurm/common.py)
+[slurmd](https://charmhub.io/integrations/slurmd), [Charm library](https://github.com/charmed-hpc/hpc-libs/blob/main/src/hpc_libs/interfaces/slurm/slurmd.py)
+[slurmdbd](https://charmhub.io/integrations/slurmdbd), [Charm library](https://github.com/charmed-hpc/hpc-libs/blob/main/src/hpc_libs/interfaces/slurm/slurmdbd.py)
+[slurmrestd](https://charmhub.io/integrations/slurmrestd), [Charm library](https://github.com/charmed-hpc/hpc-libs/blob/main/src/hpc_libs/interfaces/slurm/slurmrestd.py)
+[slurm-oci-runtime](https://charmhub.io/integrations/slurm-oci-runtime), [Charm library](https://github.com/charmed-hpc/hpc-libs/blob/main/src/hpc_libs/interfaces/slurm/oci_runtime.py)
 [cos_agent](https://charmhub.io/integrations/cos_agent), [Charm library](https://charmhub.io/grafana-agent/libraries/cos_agent)
 [ldap](https://charmhub.io/integrations/ldap/), [Charm library](https://charmhub.io/glauth-k8s/libraries/ldap)
 [mysql_client](https://charmhub.io/integrations/mysql_client), [Charm library](https://charmhub.io/data-platform-libs/libraries/data_interfaces)


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
 * [x] I have ensured that the documentation tests complete successfully.

## Summary of Changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR fixes the failing link checks that are causing our CI to wig out. In the end, we had two culprits causing the issue:

1. Some of the problematic links pointed to sections in the Juju documentation that no longer exist. I fixed them by hunting down the new sections in the Juju docs.
2. We had some links pointing to the old Slurm interface implementations. I've updated them to point to the new interface implementations in `hpc-libs`. Eventually I want us to have dedicated dev docs/a README that explains how to use the interfaces, but _I think_ we also want to evaluate moving the Slurm interfaces to a new location, so we'll cross that bridge when we get there (probably at the engineering sprint). 

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here - especially corresponding code PRs. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

This PR fixes our CI so we no longer have failing tests caused by external dependencies.
