### PR TITLE
fix: correct `multipass launch`  command in tutorial

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -53,7 +53,7 @@ From the local directory holding the cloud-init file, launch a virtual machine u
 :user: ubuntu
 :host: local
 :copy:
-:input: multipass launch 24.04 --name charmed-hpc-tutorial --cloud-init charmed-hpc-tutorial-cloud-init.yml --memory 16G --disk 40G --cpus 8 --tomeoue 1000
+:input: multipass launch 24.04 --name charmed-hpc-tutorial --cloud-init charmed-hpc-tutorial-cloud-init.yml --memory 16G --disk 40G --cpus 8 --timeout 1000
 :::
 
 The virtual machine launch process should take five minutes or less to complete, but may take longer due to network strength. Upon completion of the launch process, check the status of cloud-init to confirm that all processes completed successfully. 

--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ __Step-by-step guides__ covering key operations for [setup](howto/setup/index.md
 
 ```{grid-item-card} [Explanation](explanation/index)
 
-__Discussion and clarification__ of key topics such as [high availability](explanation/high-availability.md), [cryptography](explanation/cryptography.md), and [gpus](explanation/gpus.md)
+__Discussion and clarification__ of key topics such as [high availability](explanation/high-availability.md), [cryptography](explanation/cryptography.md), and [GPUs](explanation/gpus.md)
 
 ```
 
@@ -61,7 +61,7 @@ Here's some links to help you get started with joining the community:
 :titlesonly:
 
 self
-Getting started <getting_started>
+Getting started <getting-started>
 howto/index
 explanation/index
 reference/index


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
 * [x] I have ensured that the documentation tests complete successfully.

## Summary of Changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR fixes the `multipass launch` command in the tutorial to use the correct flag for setting the timeout threshold. 

This PR also changes the name of the tutorial file from "getting_started" to "getting-started" to follow the naming pseudo-convention we've established for our other documentation pages. This way users can have a consistent navigation experience through our doc site, and we don't have to worry about alternating between bar and underscore characters when typing out a URL from memory.

#### Related Issues, PRs, and Discussions

The inconsistency between us using bars and underscores in our URL paths wasn't noticed until after we had initially merged the tutorial. The `--timeuou` error in our `multipass launch` command was caught when we had other members of the OpenStack engineering group take a fine comb through our tutorial today during the docs office hours we have each week. 

[//]: # (Please link to related issues, pull requests, and discussions here - especially corresponding code PRs. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)



