### PR TITLE
feat: enable sphinx mermaid extension

### DIFF
--- a/.sphinx/requirements.txt
+++ b/.sphinx/requirements.txt
@@ -1,6 +1,7 @@
 canonical-sphinx[full]
 sphinx-autobuild
 sphinxcontrib-svg2pdfconverter[CairoSVG]
+sphinxcontrib-mermaid
 sphinx-last-updated-by-git
 
 GitPython

--- a/conf.py
+++ b/conf.py
@@ -254,6 +254,7 @@ myst_enable_extensions = {
 extensions = [
     "canonical_sphinx",
     "sphinxcontrib.cairosvgconverter",
+    "sphinxcontrib.mermaid",
     "sphinx_last_updated_by_git",
     "sphinx_remove_toctrees",
     "sphinx.ext.intersphinx",


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
 * [x] I have ensured that the documentation tests complete successfully.

## Summary of Changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR enables the Sphinx extension on our RTD site by following the instructions specified in https://canonical-starter-pack.readthedocs-hosted.com/latest/how-to/diagrams-as-code-mermaid/

The extension seems to work nicely, with the ability to enable interactive zooming for larger diagrams.

Here is an example diagram that I generated in the "Underlying projects and dependencies" reference documentation:

<img width="858" height="401" alt="Screenshot From 2025-10-30 12-09-38" src="https://github.com/user-attachments/assets/32d09ef1-e437-45e8-a9f1-7b3888bf985c" />

Obviously the diagram is not included in this PR, but the extension seems to work quite nicely for creating flowcharts. I was able to enable the "zoom" feature and shrink + expand the diagram so I could view certain pieces more in-depth.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here - especially corresponding code PRs. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

It's been an ongoing tasks for us to enable a Mermaid extension so that we can include reference architecture and better visuals in the tutorial.

