### PR TITLE
fix: remove duplicate warning admonition

### DIFF
--- a/howto/use/use-apptainer.md
+++ b/howto/use/use-apptainer.md
@@ -113,13 +113,6 @@ Now use the built container to compile and run your Fortran program:
 Hello world!
 :::
 
-:::{warning}
-Check with your cluster administrator before attempting to build container images
-on your Charmed HPC cluster. Each site has different policies about whether you
-can build container images directly on your cluster, and some disallow
-building container images on specific cluster resources such as login nodes.
-:::
-
 ## Provide your workload's runtime environment
 
 Apptainer can provide the runtime environment for your workloads.


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
 * [x] I have ensured that the documentation tests complete successfully.

## Summary of Changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR removes a duplicate warning admonition from the "Use Apptainer" how-to.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here - especially corresponding code PRs. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Discussed/discovered this issue during a documentation review today.



