### PR TITLE
fix: integrate sackd login nodes with filesystem-client

### DIFF
--- a/howto/setup/deploy-shared-filesystem.md
+++ b/howto/setup/deploy-shared-filesystem.md
@@ -228,10 +228,11 @@ The `mountpoint` configuration represents the path that the filesystem will be m
 
 `filesystem-client` is a [subordinate charm](https://documentation.ubuntu.com/juju/latest/reference/charm/#subordinate-charm)
 that can automatically mount any shared filesystems for the application related with it.
-In this case, we will relate it to the `slurmd` application in order to have a shared storage between
-all the compute nodes in the cluster:
+In this case, we will relate it to the `sackd` and `slurmd` applications to have shared storage
+between all the login and compute nodes in the cluster:
 
 :::{code-block} shell
+juju integrate sackd:juju-info filesystem-client:juju-info
 juju integrate slurmd:juju-info filesystem-client:juju-info
 :::
 


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
 * [x] I have ensured that the documentation tests complete successfully.

## Summary of Changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR updates the filesystem setup how-to to also integrate sackd with the `filesystem-client` charm so that login nodes also have access to the shared storage provided by NFS and CephFS.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here - especially corresponding code PRs. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- Fixes #87

