### PR TITLE
fix: Charmed-HPC -> Charmed HPC

### DIFF
--- a/howto/setup/deploy-shared-filesystem.md
+++ b/howto/setup/deploy-shared-filesystem.md
@@ -1,7 +1,7 @@
 (howto-setup-deploy-shared-filesystem)=
 # How to deploy a shared filesystem
 
-Charmed-HPC allows automatic integration with shared filesystems using the
+Charmed HPC allows automatic integration with shared filesystems using the
 [filesystem-client](https://charmhub.io/filesystem-client) charm. This how-to guide shows you how to
 deploy `filesystem-client` to integrate with externally managed shared filesystems.
 


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
 * [x] I have ensured that the documentation tests complete successfully.

## Summary of Changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)


Fixing a small consistency error I noticed when reviewing the filesystem documentation. It should be `Charmed HPC`, not `Charmed-HPC`. I think this is a holdover from when we were still discussing how "Charmed HPC" should be written as a proper noun in our documentation.

