### PR TITLE
fix(deps): pin myst-parser to version 4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 canonical-sphinx>=0.5.1
 
 # Extensions previously auto-loaded by canonical-sphinx
-myst-parser
+myst-parser ~= 4.0
 sphinx-autobuild
 sphinx-design
 sphinx-notfound-page


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
 * [x] I have ensured that the documentation tests complete successfully.

## Summary of Changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

myst-parser major API version 5 (e.g. 5.0) is incompatible with the Canonical documentation starterpack currently, so we need to hold to major API version 4 until the compatibility issues are fixed in the starterpack.

#### Related Issues, PRs, and Discussions

The documentation starterpack is incompatible with newest major API version of myst-parser, so teams using myst currently must pin to an older version of the Sphinx plugin.

[//]: # (Please link to related issues, pull requests, and discussions here - especially corresponding code PRs. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)



