### PR TITLE
feat: update "Integrate with COS" to include steps for scraping metrics from sackd and slurmd

### DIFF
--- a/howto/integrate/integrate-with-cos.md
+++ b/howto/integrate/integrate-with-cos.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: "[Get&#32;started&#32;with&#32;COS](https://documentation.ubuntu.com/observability/track-2/tutorial/installation/), [COS&#32;best&#32;practices](https://documentation.ubuntu.com/observability/track-2/reference/best-practices/)"
+relatedlinks: "[Get&#32;started&#32;with&#32;COS](https://documentation.ubuntu.com/observability/track-2/tutorial/installation/), [COS&#32;best&#32;practices](https://documentation.ubuntu.com/observability/track-2/reference/best-practices/), [Slurm&#32;metrics&#32;guide](https://slurm.schedmd.com/metrics.html)"
 ---
 
 (howto-manage-integrate-with-cos)=
@@ -67,10 +67,13 @@ Charmed HPC cluster's applications:
 
 :::{code-block}
 juju integrate opentelemetry-collector slurmctld
+juju integrate opentelemetry-collector sackd
+juju integrate opentelemetry-collector slurmd
 :::
 
 OpenTelemetry Collector will install itself on each unit of the slurmctld application
-to collect logs and metrics from Slurm.
+to collect logs and metrics from the slurmctld service's metrics endpoint. OpenTelemetry
+Collector will also scrape the metrics endpoints provided by the sackd and slurmd applications.
 
 (howto-integrate-test-connectivity-cos)=
 ## Test connectivity between Charmed HPC and COS

--- a/howto/integrate/integrate-with-cos.md
+++ b/howto/integrate/integrate-with-cos.md
@@ -2,7 +2,7 @@
 relatedlinks: "[Get&#32;started&#32;with&#32;COS](https://documentation.ubuntu.com/observability/track-2/tutorial/installation/), [COS&#32;best&#32;practices](https://documentation.ubuntu.com/observability/track-2/reference/best-practices/), [Slurm&#32;metrics&#32;guide](https://slurm.schedmd.com/metrics.html)"
 myst:
   html_meta:
-    description: Learn how to integrate Charmed HPC with the Canonical Observability Stack (COS) to monitor your cluster by forwarding logs and metrics for interactive analysis.
+    description: Instructions on how to integrate Charmed HPC with the Canonical Observability Stack (COS) to monitor your cluster by forwarding logs and metrics for interactive analysis.
 ---
 
 (howto-manage-integrate-with-cos)=
@@ -74,9 +74,9 @@ juju integrate opentelemetry-collector sackd
 juju integrate opentelemetry-collector slurmd
 :::
 
-OpenTelemetry Collector will install itself on each unit of the slurmctld application
-to collect logs and metrics from the slurmctld service's metrics endpoint. OpenTelemetry
-Collector will also scrape the metrics endpoints provided by the sackd and slurmd applications.
+OpenTelemetry Collector will install itself on each unit of the `slurmctld` application
+to collect logs and metrics from the slurmctld service's metrics endpoint. It will also scrape
+the metrics endpoints provided by the `sackd` and `slurmd` applications.
 
 (howto-integrate-test-connectivity-cos)=
 ## Test connectivity between Charmed HPC and COS

--- a/howto/integrate/integrate-with-cos.md
+++ b/howto/integrate/integrate-with-cos.md
@@ -1,5 +1,8 @@
 ---
 relatedlinks: "[Get&#32;started&#32;with&#32;COS](https://documentation.ubuntu.com/observability/track-2/tutorial/installation/), [COS&#32;best&#32;practices](https://documentation.ubuntu.com/observability/track-2/reference/best-practices/), [Slurm&#32;metrics&#32;guide](https://slurm.schedmd.com/metrics.html)"
+myst:
+  html_meta:
+    description: Learn how to integrate Charmed HPC with the Canonical Observability Stack (COS) to monitor your cluster by forwarding logs and metrics for interactive analysis.
 ---
 
 (howto-manage-integrate-with-cos)=


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
 * [x] I have ensured that the documentation tests complete successfully.
 * [x] I have added a metadata description at the top of any new page.

## Summary of Changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds additional steps for integrating the OpenTelemetry Collector application with sackd and slurmd applications to scrape metrics from their node exporter endpoints.

Also, I used the SKILL file to add a metadata description to the "Integrate with COS" how-to.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here - especially corresponding code PRs. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Related to our ongoing work to add additional Prometheus alerts to our compute and controller operators.

