### PR TITLE
feat: add prometheus alert rules to monitoring section

### DIFF
--- a/.github/skills/generate-prometheus-alerts-reference/SKILL.md
+++ b/.github/skills/generate-prometheus-alerts-reference/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: generate-prometheus-alerts-reference
+description: 'Generate a reference documentation page for the Prometheus alert rules used in Charmed HPC. Uses the GitHub MCP server to scan charm repositories for alert rule definitions and produces a MyST Markdown page listing all alerts with their severity and description.'
+argument-hint: 'No arguments required. Run this skill to regenerate the Prometheus alerts reference page.'
+---
+
+# Generate Prometheus Alerts Reference
+
+Scans the primary Charmed HPC charm repositories on GitHub for Prometheus alert rule files and generates a reference documentation page at `reference/monitoring/prometheus-alerts.md`.
+
+## Repositories to scan
+
+Use the GitHub MCP server tools (`mcp_github_get_file_contents`) to scan the following repositories for Prometheus alert rules:
+
+1. `charmed-hpc/slurm-charms` — look inside each charm directory under `charms/*/src/cos/alert_rules/prometheus/`
+2. `charmed-hpc/sssd-operator` — look under `src/cos/alert_rules/prometheus/`
+3. `charmed-hpc/filesystem-charms` — look inside each charm directory under `charms/*/src/cos/alert_rules/prometheus/`
+4. `charmed-hpc/apptainer-operator` — look under `src/cos/alert_rules/prometheus/`
+
+Alert rule files use the `.rule` or `.rules` extension and are in YAML format.
+
+Files with the `.rule` extension contain a single alert rule with the following structure:
+
+```yaml
+alert: AlertName
+expr: <PromQL expression>
+for: <duration>
+labels:
+  severity: <warning|critical>
+annotations:
+  summary: <short summary>
+  description: >
+    <detailed description>
+```
+
+Files with the `.rules` extension use the Prometheus rule group schema and may contain multiple alert rules:
+
+```yaml
+groups:
+  - name: <group name>
+    rules:
+      - alert: AlertName
+        expr: <PromQL expression>
+        for: <duration>
+        labels:
+          severity: <warning|critical>
+        annotations:
+          summary: <short summary>
+          description: >
+            <detailed description>
+```
+
+## Process
+
+1. **Scan repositories** — For each repository listed above, use the GitHub MCP server to list the contents of the Prometheus alert rules directories. For monorepos (`slurm-charms`, `filesystem-charms`), iterate over each charm subdirectory.
+
+2. **Read alert rule files** — For each `.rule` or `.rules` file found, retrieve its content using the GitHub MCP server and extract:
+   - `alert` — the alert name
+   - `labels.severity` — the severity level (e.g. "warning", "critical")
+   - `annotations.summary` or `annotations.description` — a human-readable description of when the alert fires
+
+3. **Group alerts by charm** — Organise the collected alerts by the charm that provides them (e.g. `slurmctld`, `slurmd`, `sssd`).
+
+4. **Generate the documentation page** — Write the file `reference/monitoring/prometheus-alerts.md` using the format specified below.
+
+5. **Update the monitoring index** — Add the new page to the toctree in `reference/monitoring/index.md` and to the bullet list of pages.
+
+## Output format
+
+The generated page MUST follow this exact MyST Markdown structure:
+
+```markdown
+(reference-monitoring-prometheus-alerts)=
+# Prometheus alerts
+
+This page lists the Prometheus alert rules provided by Charmed HPC charms. These alerts
+fire when specific conditions are met in your cluster and can be viewed in the Prometheus
+or {term}`Grafana` web interface.
+
+See {ref}`howto-manage-integrate-with-cos` for instructions on integrating with COS.
+
+```{note}
+The tables below provide the following information:
+
+- **Alert**: the alert name as shown in the Prometheus dashboard.
+- **Description**: a summary of when the alert is triggered.
+- **Severity**: the alert severity (`warning` or `critical`).
+```
+
+## <Charm name>
+
+:::{list-table}
+:header-rows: 1
+
+* - Alert
+  - Description
+  - Severity
+* - `AlertName`
+  - Description of when the alert fires.
+  - warning
+:::
+```
+
+Repeat the `## <Charm name>` section and table for each charm that has alert rules. Use the charm directory name as the section heading (e.g. "Slurmctld", "Slurmd"). Capitalise the first letter.
+
+If a repository or charm has no alert rules, omit it from the output entirely — do NOT include empty sections.
+
+## Updating the monitoring index
+
+After generating the page, ensure `reference/monitoring/index.md` includes the new page:
+
+1. Add a bullet point in the content list:
+   ```markdown
+   - {ref}`Prometheus alerts <reference-monitoring-prometheus-alerts>`
+   ```
+
+2. Add to the toctree:
+   ```markdown
+   Prometheus alerts <prometheus-alerts>
+   ```
+
+## Constraints
+
+- ONLY use `mcp_github_get_file_contents` from the GitHub MCP server to retrieve repository contents. Do NOT clone repositories locally.
+- DO NOT invent or fabricate alert rules. Only document alerts that actually exist in the repositories at the time of generation.
+- DO NOT modify any other documentation pages except `reference/monitoring/prometheus-alerts.md` and `reference/monitoring/index.md`.
+- If no alert rules are found in any repository, report this to the user instead of generating an empty page.
+- Use MyST Markdown (`.md`), NOT reStructuredText (`.rst`).
+- The page title MUST be "Prometheus alerts".
+- The cross-reference label MUST be `(reference-monitoring-prometheus-alerts)=`.
+

--- a/howto/integrate/integrate-with-cos.md
+++ b/howto/integrate/integrate-with-cos.md
@@ -208,7 +208,7 @@ You can see the available dashboards by opening the sidebar menu and clicking on
 
 You can now use COS to monitor your Charmed HPC cluster.
 
-You can also start exploring the {ref}`reference-monitoring-grafana`,
-{ref}`reference-monitoring-loki`, and {ref}`reference-monitoring-prometheus`
+You can also start exploring the {ref}`reference-monitoring-grafana-dashboards`,
+{ref}`reference-monitoring-loki-logs`, and {ref}`reference-monitoring-prometheus-metrics`
 sections in the {ref}`reference-monitoring` section for an overview of all
 the metrics, logs, and dashboards that are provided by your Charmed HPC cluster.

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 # Charmed HPC
 
-Charmed HPC is a platform for managing high-performance computing clusters. It automates the lifecycle of essential cluster software and processes, such as workload management, shared storage, GPU access, and high-bandwidth networking. This allows operations teams and systems administrators to focus on running workloads rather than maintaining infrastructure. 
+Charmed HPC is a platform for managing high-performance computing clusters. It automates the lifecycle of essential cluster software and processes, such as workload management, shared storage, GPU access, and high-bandwidth networking. This allows operations teams and systems administrators to focus on running workloads rather than maintaining infrastructure.
 <!-- Charmed HPC is a versatile high-performance computing platform that facilitates the set up and maintenance of HPC clusters. This is done by autonomizing the deployment, integration, and life-cycle management of essential cluster software that enables users to run modern workloads at scale.
 
 Charmed HPC spins up turnkey clusters on a variety of cloud platforms to support write-once, run-anywhere user workloads. It also provides the necessary integrations for GPUs, high bandwidth networking, and shared storage.
@@ -12,7 +12,7 @@ The platform enables organizations to focus on obtaining key insights and making
 ## In this documentation
 
 - __Learn more about Charmed HPC:__ [Getting Started tutorial](tutorial-getting-started-with-charmed-hpc), [Underlying projects](reference/underlying-projects-and-dependencies.md)
-- __Workload management:__ [Deploy Slurm](howto/deploy/deploy-slurm.md), [Manage Slurm](howto/manage/manage-slurm.md), [Clean up Slurm](howto/cleanup/cleanup-slurm.md), [Grafana Dashboards](reference/monitoring/grafana.md) 
+- __Workload management:__ [Deploy Slurm](howto/deploy/deploy-slurm.md), [Manage Slurm](howto/manage/manage-slurm.md), [Clean up Slurm](howto/cleanup/cleanup-slurm.md), [Grafana Dashboards](reference/monitoring/grafana-dashboards.md)
 - __Storage and Resources:__ [Deploy shared filesystem](howto/deploy/deploy-shared-filesystem.md), [GPUs](explanation/gpus.md), [GRES](reference/gpus.md), [Interconnects](explanation/interconnects.md)
 - __Security and Identity:__ [Deploy identity provider](howto/deploy/deploy-identity-provider.md), [Hardening guidelines](reference/hardening.md), [Cryptography](explanation/cryptography.md)
 - __Performance:__ [High availability](explanation/high-availability.md), [Benchmarks](reference/performance.md)

--- a/reference/index.md
+++ b/reference/index.md
@@ -26,9 +26,10 @@ Security configurations, recommendations, and reference data for the components 
 
 Dashboards, metrics, and log queries available when COS is integrated with a Charmed HPC cluster.
 
-- {ref}`reference-monitoring-grafana`
-- {ref}`reference-monitoring-prometheus`
-- {ref}`reference-monitoring-loki`
+- {ref}`reference-monitoring-grafana-dashboards`
+- {ref}`reference-monitoring-loki-logs`
+- {ref}`reference-monitoring-prometheus-alerts`
+- {ref}`reference-monitoring-prometheus-metrics`
 
 ## Performance
 

--- a/reference/monitoring/grafana-dashboards.md
+++ b/reference/monitoring/grafana-dashboards.md
@@ -2,7 +2,7 @@
 relatedlinks: "[Grafana&#32;dashboards&#32;documentation](https://grafana.com/docs/grafana/latest/dashboards/)"
 ---
 
-(reference-monitoring-grafana)=
+(reference-monitoring-grafana-dashboards)=
 # Grafana dashboards
 
 This is an overview of all the charms used in Charmed HPC that provide dashboards for

--- a/reference/monitoring/grafana-dashboards.md
+++ b/reference/monitoring/grafana-dashboards.md
@@ -1,5 +1,8 @@
 ---
 relatedlinks: "[Grafana&#32;dashboards&#32;documentation](https://grafana.com/docs/grafana/latest/dashboards/)"
+myst:
+  html_meta:
+    description: Grafana dashboards provided by Charmed HPC, covering cluster, partition, node, MySQL, and Traefik metrics visualizations.
 ---
 
 (reference-monitoring-grafana-dashboards)=

--- a/reference/monitoring/index.md
+++ b/reference/monitoring/index.md
@@ -5,16 +5,18 @@ Integrating COS with Charmed HPC enables you to monitor your Charmed HPC cluster
 with {term}`Prometheus`, {term}`Grafana`, and {term}`Loki`. The reference material in
 this section list the dashboards and metrics from Charmed HPC that you can interact with.
 
-- {ref}`Prometheus: metrics aggregation and alerts <reference-monitoring-prometheus>`
-- {ref}`Grafana: Dashboards and resource visualizations <reference-monitoring-grafana>`
-- {ref}`Loki: Logs aggregator <reference-monitoring-loki>`
+- {ref}`Grafana: Dashboards and resource visualizations <reference-monitoring-grafana-dashboards>`
+- {ref}`Loki: Logs aggregator <reference-monitoring-loki-logs>`
+- {ref}`Prometheus: alerts <reference-monitoring-prometheus-alerts>`
+- {ref}`Prometheus: metrics aggregation <reference-monitoring-prometheus-metrics>`
 
 ```{filtered-toctree}
 :titlesonly:
 :maxdepth: 1
 :hidden:
 
-Prometheus <prometheus>
-Grafana <grafana>
-Loki <loki>
+Grafana dashboards <grafana-dashboards>
+Loki logs <loki-logs>
+Prometheus alerts <prometheus-alerts>
+Prometheus metrics <prometheus-metrics>
 ```

--- a/reference/monitoring/loki-logs.md
+++ b/reference/monitoring/loki-logs.md
@@ -1,3 +1,8 @@
+---
+myst:
+  html_meta:
+    description: Reference page for the Loki log queries for Charmed HPC charms, including slurmctld, slurmd, slurmdbd, MySQL, and GLAuth, and how to exclude unwanted log files.
+---
 (reference-monitoring-loki-logs)=
 # Loki logs
 

--- a/reference/monitoring/loki-logs.md
+++ b/reference/monitoring/loki-logs.md
@@ -1,4 +1,4 @@
-(reference-monitoring-loki)=
+(reference-monitoring-loki-logs)=
 # Loki logs
 
 The following table lists all the charms used as part of Charmed HPC that expose logs to {term}`Loki`, and the

--- a/reference/monitoring/prometheus-alerts.md
+++ b/reference/monitoring/prometheus-alerts.md
@@ -1,0 +1,94 @@
+(reference-monitoring-prometheus-alerts)=
+# Prometheus alerts
+
+This page lists the Prometheus alert rules provided by Charmed HPC charms. These alerts
+fire when specific conditions are met in your cluster and can be viewed in the Prometheus
+or {term}`Grafana` web interface.
+
+See {ref}`howto-manage-integrate-with-cos` for instructions on integrating with COS.
+
+```{note}
+The tables below provide the following information:
+
+- **Alert**: the alert name as shown in the Prometheus dashboard.
+- **Description**: a summary of when the alert is triggered.
+- **Severity**: the alert severity (`warning` or `critical`).
+```
+
+## Sackd
+
+:::{list-table}
+:header-rows: 1
+
+* - Alert
+  - Description
+  - Severity
+* - `SlurmLoginNodeSackdServiceIsInactive`
+  - The `sackd` service has been inactive for more than 5 minutes on a login node.
+  - warning
+* - `SlurmLoginNodeSackdServiceHasFailed`
+  - The `sackd` service has failed on a login node.
+  - critical
+:::
+
+## Slurmctld
+
+:::{list-table}
+:header-rows: 1
+
+* - Alert
+  - Description
+  - Severity
+* - `SlurmJobsHighFailureRate`
+  - More than 10 jobs have failed in the last 15 minutes.
+  - warning
+* - `SlurmJobsPendingForTooLong`
+  - More than 10 jobs have been pending for longer than 1 hour.
+  - warning
+* - `SlurmPartitionNearingFull`
+  - A partition has less than 10% of its nodes idle.
+  - warning
+* - `SlurmPartitionMaxMemoryLimit`
+  - A partition has allocated more than 90% of its available memory.
+  - warning
+* - `SlurmPartitionMaxCPULimit`
+  - A partition has allocated more than 90% of its available CPU capacity.
+  - warning
+* - `SlurmTooManyFailedDbdMessages`
+  - The Slurm controller's pending message queue to the Slurm database exceeded 5000 in the past minute.
+  - critical
+* - `SlurmNodesDrainingTooLong`
+  - One or more compute nodes have been draining for more than 3 hours.
+  - warning
+* - `SlurmNodesFailing`
+  - One or more compute nodes have been reporting as `FAIL` for more than 5 minutes.
+  - critical
+* - `SlurmNodesNotResponding`
+  - One or more compute nodes are not responding to the Slurm controller for more than 5 minutes.
+  - critical
+* - `SlurmNodesInUnknownState`
+  - One or more compute nodes have been reporting as `UNKNOWN` for more than 5 minutes.
+  - critical
+:::
+
+## Slurmd
+
+:::{list-table}
+:header-rows: 1
+
+* - Alert
+  - Description
+  - Severity
+* - `SlurmComputeNodeSlurmdServiceIsInactive`
+  - The `slurmd` service has been inactive for more than 5 minutes on a compute node.
+  - warning
+* - `SlurmComputeNodeSlurmdServiceHasFailed`
+  - The `slurmd` service has failed on a compute node.
+  - critical
+* - `SlurmComputeNodeNvidiaGPUIsOverheating`
+  - A GPU has exceeded 90°C on a compute node.
+  - warning
+* - `SlurmComputeNodeGPUXIDErrorsDetected`
+  - XID errors are being reported on a GPU on a compute node.
+  - warning
+:::

--- a/reference/monitoring/prometheus-alerts.md
+++ b/reference/monitoring/prometheus-alerts.md
@@ -1,3 +1,8 @@
+---
+myst:
+  html_meta:
+    description: Reference list of Prometheus alert rules provided by Charmed HPC charms, grouped by charm, with severity levels and trigger descriptions.
+---
 (reference-monitoring-prometheus-alerts)=
 # Prometheus alerts
 
@@ -55,7 +60,7 @@ The tables below provide the following information:
   - A partition has allocated more than 90% of its available CPU capacity.
   - warning
 * - `SlurmTooManyFailedDbdMessages`
-  - The Slurm controller's pending message queue to the Slurm database exceeded 5000 in the past minute.
+  - The amount of pending messages from the Slurm controller to the Slurm database exceeded 5000 in the past minute.
   - critical
 * - `SlurmNodesDrainingTooLong`
   - One or more compute nodes have been draining for more than 3 hours.

--- a/reference/monitoring/prometheus-metrics.md
+++ b/reference/monitoring/prometheus-metrics.md
@@ -1,7 +1,7 @@
-(reference-monitoring-prometheus)=
-# Prometheus metrics and alerts
+(reference-monitoring-prometheus-metrics)=
+# Prometheus metrics
 
-This is an overview of all the charms used in Charmed HPC that provide monitoring metrics and alerts
+This is an overview of all the charms used in Charmed HPC that provide monitoring metrics
 for {term}`Prometheus`, a metrics aggregator and alerts manager for applications.
 
 All metrics and alerts can be viewed from Prometheus or from the {term}`Grafana` web interface.

--- a/reference/monitoring/prometheus-metrics.md
+++ b/reference/monitoring/prometheus-metrics.md
@@ -1,3 +1,8 @@
+---
+myst:
+  html_meta:
+    description: Reference for Charmed HPC charms that expose Prometheus metrics, with upstream documentation links and queries for Prometheus and Grafana.
+---
 (reference-monitoring-prometheus-metrics)=
 # Prometheus metrics
 


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
 * [x] I have ensured that the documentation tests complete successfully.
 * [x] I have added a metadata description at the top of any new page.

## Summary of Changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR adds a new reference documentation page for the new Prometheus alert rules added to Charmed HPC. It also renames the existing monitoring reference documentation pages to better surface what each monitoring component does. _Not everyone in HPC may be familiar with Grafana, Loki. or Prometheus._

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here - especially corresponding code PRs. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

Related to our ongoing work to enhance the observability of Charmed HPC.

### Other changes

1. I added metadata descriptions to the reference documentation pages using the metadata skill.
2. I added a new skill for creating the prometheus alert rules reference pages.
