### PR TITLE
feat: change `login-node` integration endpoint name to `sackd`

### DIFF
--- a/howto/deploy/deploy-slurm.md
+++ b/howto/deploy/deploy-slurm.md
@@ -1,7 +1,7 @@
 ---
 myst:
   html_meta:
-    description: Instructions on how to deploy Slurm in a standalone or high-availability configuration with Juju.
+    description: Instructions on how to use Juju to deploy Slurm in either a standalone or high-availability configuration as the workload manager of a Charmed HPC cluster.
 relatedlinks: "[Slurm&#32;website](https://slurm.schedmd.com/overview.html), [Slurm&#32;charms&#32;repository](https://github.com/charmed-hpc/slurm-charms)"
 ---
 

--- a/howto/deploy/deploy-slurm.md
+++ b/howto/deploy/deploy-slurm.md
@@ -1,4 +1,7 @@
 ---
+myst:
+  html_meta:
+    description: Instructions on how to deploy Slurm in a standalone or high-availability configuration with Juju.
 relatedlinks: "[Slurm&#32;website](https://slurm.schedmd.com/overview.html), [Slurm&#32;charms&#32;repository](https://github.com/charmed-hpc/slurm-charms)"
 ---
 

--- a/reuse/howto/setup/deploy-slurm/slurm.tf
+++ b/reuse/howto/setup/deploy-slurm/slurm.tf
@@ -54,7 +54,7 @@ resource "juju_integration" "sackd_to_slurmctld" {
 
   application {
     name     = module.slurmctld.app_name
-    endpoint = module.slurmctld.requires.login-node
+    endpoint = module.slurmctld.requires.sackd
   }
 }
 


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
 * [x] I have ensured that the documentation tests complete successfully.
 * [x] I have added a metadata description at the top of any new page.

## Summary of Changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR updates the only reference to the `login-node` integration endpoint in our documentation to its new name, `sackd`. This PR also adds a metadata description to the "Deploy Slurm" how-to utilizing the `add-metadata-description` skill file.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here - especially corresponding code PRs. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- Documentation PR for https://github.com/charmed-hpc/slurm-charms/pull/228.

