### PR TITLE
fix: add instructions for integrating SSSD with slurmctld

### DIFF
--- a/howto/deploy/deploy-identity-provider.md
+++ b/howto/deploy/deploy-identity-provider.md
@@ -1,3 +1,9 @@
+---
+myst:
+  html_meta:
+    description: Instructions on how to use Juju to deploy and integrate an LDAP-based identity provider with SSSD to provide remote users to a Charmed HPC cluster.
+---
+
 (howto-deploy-deploy-identity-provider)=
 # How to deploy an identity provider
 

--- a/reuse/howto/setup/deploy-identity-provider/common/deploy-sssd.txt
+++ b/reuse/howto/setup/deploy-identity-provider/common/deploy-sssd.txt
@@ -10,11 +10,12 @@ juju deploy sssd --base "ubuntu@24.04" --channel "edge"
 :::
 
 Now use `juju integrate`{l=shell} to integrate SSSD with the Slurm services
-`sackd` and `slurmd`:
+`sackd`, `slurmd`, and `slurmctld`:
 
 :::{code-block} shell
 juju integrate sssd sackd
 juju integrate sssd slurmd
+juju integrate sssd slurmctld
 :::
 
 ::::
@@ -39,12 +40,12 @@ to your configuration:
 :lines: 1-8
 :::
 
-Now declare data sources for the `slurm` model, and your sackd and slurmd applications:
+Now declare data sources for the `slurm` model, and your sackd, slurmd, and slurmctld applications:
 
 :::{literalinclude} /reuse/howto/setup/deploy-identity-provider/common/sssd.tf
 :caption: {{ sssd_tf_file }}
 :language: terraform
-:lines: 10-23
+:lines: 10-28
 :::
 
 Now deploy SSSD:
@@ -52,15 +53,15 @@ Now deploy SSSD:
 :::{literalinclude} /reuse/howto/setup/deploy-identity-provider/common/sssd.tf
 :caption: {{ sssd_tf_file }}
 :language: terraform
-:lines: 24-28
+:lines: 30-34
 :::
 
-Now connect SSSD to the sackd and slurmd applications in your `slurm` model:
+Now connect SSSD to the sackd, slurmd, and slurmctld applications in your `slurm` model:
 
 :::{literalinclude} /reuse/howto/setup/deploy-identity-provider/common/sssd.tf
 :caption: {{ sssd_tf_file }}
 :language: terraform
-:lines: 29-52
+:lines: 35-69
 :::
 
 You can expand the dropdown below to see the full _{{ sssd_tf_file }}_ Terraform configuration file. Now use the `terraform`{l=shell} command to apply your configuration.
@@ -100,13 +101,14 @@ slurmctld   23.11.4-1.2u...  active       1  slurmctld   latest/edge   95  no
 slurmd      23.11.4-1.2u...  active       1  slurmd      latest/edge  116  no
 slurmdbd    23.11.4-1.2u...  active       1  slurmdbd    latest/edge   87  no
 slurmrestd  23.11.4-1.2u...  active       1  slurmrestd  latest/edge   89  no
-sssd        2.9.4-1.1ubu...  waiting      2  sssd        latest/edge    6  no       Waiting for integrations: [`ldap`]
+sssd        2.9.4-1.1ubu...  waiting      3  sssd        latest/edge    6  no       Waiting for integrations: [`ldap`]
 
 Unit           Workload  Agent  Machine  Public address  Ports           Message
 mysql/0*       active    idle   3        10.175.90.111   3306,33060/tcp  Primary
 sackd/0*       active    idle   0        10.175.90.64
   sssd/1       waiting   idle            10.175.90.64                    Waiting for integrations: [`ldap`]
 slurmctld/0*   active    idle   4        10.175.90.100
+  sssd/2       waiting   idle            10.175.90.100                   Waiting for integrations: [`ldap`]
 slurmd/0*      active    idle   5        10.175.90.107
   sssd/0*      waiting   idle            10.175.90.107                   Waiting for integrations: [`ldap`]
 slurmdbd/0*    active    idle   2        10.175.90.105

--- a/reuse/howto/setup/deploy-identity-provider/common/sssd-with-ldap-status.txt
+++ b/reuse/howto/setup/deploy-identity-provider/common/sssd-with-ldap-status.txt
@@ -19,13 +19,14 @@ slurmctld   23.11.4-1.2u...  active      1  slurmctld   latest/edge   95  no
 slurmd      23.11.4-1.2u...  active      1  slurmd      latest/edge  116  no
 slurmdbd    23.11.4-1.2u...  active      1  slurmdbd    latest/edge   87  no
 slurmrestd  23.11.4-1.2u...  active      1  slurmrestd  latest/edge   89  no
-sssd        2.9.4-1.1ubu...  active      2  sssd        latest/edge    6  no
+sssd        2.9.4-1.1ubu...  active      3  sssd        latest/edge    6  no
 
 Unit           Workload  Agent  Machine  Public address  Ports           Message
 mysql/0*       active    idle   3        10.175.90.111   3306,33060/tcp  Primary
 sackd/0*       active    idle   0        10.175.90.64
   sssd/1       active    idle            10.175.90.64
 slurmctld/0*   active    idle   4        10.175.90.100
+  sssd/2       active    idle            10.175.90.100
 slurmd/0*      active    idle   5        10.175.90.107
   sssd/0*      active    idle            10.175.90.107
 slurmdbd/0*    active    idle   2        10.175.90.105

--- a/reuse/howto/setup/deploy-identity-provider/common/sssd-with-ldap-tls-status.txt
+++ b/reuse/howto/setup/deploy-identity-provider/common/sssd-with-ldap-tls-status.txt
@@ -20,13 +20,14 @@ slurmctld   23.11.4-1.2u...  active      1  slurmctld   latest/edge   95  no
 slurmd      23.11.4-1.2u...  active      1  slurmd      latest/edge  116  no
 slurmdbd    23.11.4-1.2u...  active      1  slurmdbd    latest/edge   87  no
 slurmrestd  23.11.4-1.2u...  active      1  slurmrestd  latest/edge   89  no
-sssd        2.9.4-1.1ubu...  active      2  sssd        latest/edge    6  no
+sssd        2.9.4-1.1ubu...  active      3  sssd        latest/edge    6  no
 
 Unit           Workload  Agent  Machine  Public address  Ports           Message
 mysql/0*       active    idle   3        10.175.90.111   3306,33060/tcp  Primary
 sackd/0*       active    idle   0        10.175.90.64
   sssd/1       active    idle            10.175.90.64
 slurmctld/0*   active    idle   4        10.175.90.100
+  sssd/2       active    idle            10.175.90.100
 slurmd/0*      active    idle   5        10.175.90.107
   sssd/0*      active    idle            10.175.90.107
 slurmdbd/0*    active    idle   2        10.175.90.105

--- a/reuse/howto/setup/deploy-identity-provider/common/sssd.tf
+++ b/reuse/howto/setup/deploy-identity-provider/common/sssd.tf
@@ -17,6 +17,11 @@ data "juju_application" "sackd" {
   name       = "sackd"
 }
 
+data "juju_application" "slurmctld" {
+  model_uuid = data.juju_model.slurm.uuid
+  name       = "slurmctld"
+}
+
 data "juju_application" "slurmd" {
   model_uuid = data.juju_model.slurm.uuid
   name       = "slurmd"
@@ -27,7 +32,7 @@ module "sssd" {
   model_uuid = data.juju_model.slurm.uuid
 }
 
-resource "juju_integration" "sssd-to-sackd" {
+resource "juju_integration" "sssd_to_sackd" {
   model_uuid = data.juju_model.slurm.uuid
 
   application {
@@ -39,7 +44,19 @@ resource "juju_integration" "sssd-to-sackd" {
   }
 }
 
-resource "juju_integration" "sssd-to-slurmd" {
+resource "juju_integration" "sssd_to_slurmctld" {
+  model_uuid = data.juju_model.slurm.uuid
+
+  application {
+    name = module.sssd.app_name
+  }
+
+  application {
+    name = data.juju_application.slurmctld.name
+  }
+}
+
+resource "juju_integration" "sssd_to_slurmd" {
   model_uuid = data.juju_model.slurm.uuid
 
   application {


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
 * [x] I have ensured that the documentation tests complete successfully.
 * [x] I have added a metadata description at the top of any new page.

## Summary of Changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR updates the "Deploy identity provider" how-to to include instructions for integrating SSSD with the slurmctld application. SSSD is required on slurmctld units so that Slurm can successfully authenticate remote users when a new job is submitted.

Also, I added a metadata description to the "Deploy identity provider" how-to page.

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here - especially corresponding code PRs. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

- Fixes https://github.com/charmed-hpc/docs/issues/137
