### PR TITLE
docs(cleanup): update existing examples to use CC008-compliant HPC Terraform modules

### DIFF
--- a/reuse/howto/setup/deploy-identity-provider/common/sssd.tf
+++ b/reuse/howto/setup/deploy-identity-provider/common/sssd.tf
@@ -28,7 +28,7 @@ data "juju_application" "slurmd" {
 }
 
 module "sssd" {
-  source     = "git::https://github.com/canonical/sssd-operator//terraform"
+  source     = "git::https://github.com/charmed-hpc/sssd-operator//terraform"
   model_uuid = data.juju_model.slurm.uuid
 }
 
@@ -36,7 +36,7 @@ resource "juju_integration" "sssd_to_sackd" {
   model_uuid = data.juju_model.slurm.uuid
 
   application {
-    name = module.sssd.app_name
+    name = module.sssd.application.name
   }
 
   application {
@@ -48,7 +48,7 @@ resource "juju_integration" "sssd_to_slurmctld" {
   model_uuid = data.juju_model.slurm.uuid
 
   application {
-    name = module.sssd.app_name
+    name = module.sssd.application.name
   }
 
   application {
@@ -60,7 +60,7 @@ resource "juju_integration" "sssd_to_slurmd" {
   model_uuid = data.juju_model.slurm.uuid
 
   application {
-    name = module.sssd.app_name
+    name = module.sssd.application.name
   }
 
   application {

--- a/reuse/howto/setup/deploy-identity-provider/ldap-integrator/ldap-integrator.tf
+++ b/reuse/howto/setup/deploy-identity-provider/ldap-integrator/ldap-integrator.tf
@@ -34,11 +34,11 @@ module "ldap_integrator" {
     urls          = "ldap://10.214.237.229"
   }
 
-  channel = "latest/edge"
+  channel = "latest/stable"
 }
 
 resource "juju_access_secret" "grant_external_ldap_password_secret" {
-  applications = [module.ldap_integrator.app_name]
+  applications = [module.ldap_integrator.application.name]
   model_uuid   = juju_model.identity.uuid
   secret_id    = juju_secret.external_ldap_password.secret_id
 }

--- a/reuse/howto/setup/deploy-slurm/slurm-ha.tf
+++ b/reuse/howto/setup/deploy-slurm/slurm-ha.tf
@@ -7,12 +7,12 @@ resource "juju_integration" "provider_to_filesystem" {
   model_uuid = juju_model.slurm.uuid
 
   application {
-    name     = module.[filesystem-provider].app_name
+    name     = module.[filesystem-provider].application.name
     endpoint = module.[filesystem-provider].provides.filesystem
   }
 
   application {
-    name     = module.filesystem-client.app_name
+    name     = module.filesystem-client.application.name
     endpoint = module.filesystem-client.requires.filesystem
   }
 }
@@ -27,12 +27,12 @@ resource "juju_integration" "filesystem-to-slurmctld" {
   model_uuid = juju_model.slurm.uuid
 
   application {
-    name     = module.slurmctld.app_name
+    name     = module.slurmctld.application.name
     endpoint = module.slurmctld.provides.mount
   }
 
   application {
-    name     = module.filesystem-client.app_name
+    name     = module.filesystem-client.application.name
     endpoint = module.filesystem-client.requires.mount
   }
 }

--- a/reuse/howto/setup/deploy-slurm/slurm.tf
+++ b/reuse/howto/setup/deploy-slurm/slurm.tf
@@ -48,12 +48,12 @@ resource "juju_integration" "sackd_to_slurmctld" {
   model_uuid = juju_model.slurm.uuid
 
   application {
-    name     = module.sackd.app_name
+    name     = module.sackd.application.name
     endpoint = module.sackd.provides.slurmctld
   }
 
   application {
-    name     = module.slurmctld.app_name
+    name     = module.slurmctld.application.name
     endpoint = module.slurmctld.requires.sackd
   }
 }
@@ -62,12 +62,12 @@ resource "juju_integration" "slurmd_to_slurmctld" {
   model_uuid = juju_model.slurm.uuid
 
   application {
-    name     = module.slurmd.app_name
+    name     = module.slurmd.application.name
     endpoint = module.slurmd.provides.slurmctld
   }
 
   application {
-    name     = module.slurmctld.app_name
+    name     = module.slurmctld.application.name
     endpoint = module.slurmctld.requires.slurmd
   }
 }
@@ -76,12 +76,12 @@ resource "juju_integration" "slurmdbd_to_slurmctld" {
   model_uuid = juju_model.slurm.uuid
 
   application {
-    name     = module.slurmdbd.app_name
+    name     = module.slurmdbd.application.name
     endpoint = module.slurmdbd.provides.slurmctld
   }
 
   application {
-    name     = module.slurmctld.app_name
+    name     = module.slurmctld.application.name
     endpoint = module.slurmctld.requires.slurmdbd
   }
 }
@@ -90,12 +90,12 @@ resource "juju_integration" "slurmrestd_to_slurmctld" {
   model_uuid = juju_model.slurm.uuid
 
   application {
-    name     = module.slurmrestd.app_name
+    name     = module.slurmrestd.application.name
     endpoint = module.slurmrestd.provides.slurmctld
   }
 
   application {
-    name     = module.slurmctld.app_name
+    name     = module.slurmctld.application.name
     endpoint = module.slurmctld.requires.slurmrestd
   }
 }
@@ -109,7 +109,7 @@ resource "juju_integration" "slurmdbd_to_mysql" {
   }
 
   application {
-    name     = module.slurmdbd.app_name
+    name     = module.slurmdbd.application.name
     endpoint = module.slurmdbd.requires.database
   }
 }


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
 * [x] I have ensured that the documentation tests complete successfully.
 * [x] I have added a metadata description at the top of any new page.

## Summary of Changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

This PR updates our Terraform examples to use the CC008-compliant HPC charm modules. I'll be opening several piecemeal PRs as other charms around the ecosystem update their modules to be CC008 compliant. 

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here - especially corresponding code PRs. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)

The existing Terraform examples in our docs are outdated.

