### PR TITLE
Changing LXD Version for Tutorial to 5.21/stable

### DIFF
--- a/reuse/tutorial/charmed-hpc-tutorial-cloud-init.yml
+++ b/reuse/tutorial/charmed-hpc-tutorial-cloud-init.yml
@@ -11,7 +11,7 @@ package_upgrade: true
 snap:
   commands:
     00: snap install juju --channel=3/stable
-    01: snap install lxd --channel=6/stable
+    01: snap install lxd --channel=5.21/stable
 
 # Configure and initialize prerequisites
 lxd:


### PR DESCRIPTION
# Pre-submission checklist

 * [X] I read and followed the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
 * [X] I have ensured that the documentation tests complete successfully.
 * [X] I have added a metadata description at the top of any new page.

## Summary of Changes

[//]: Changing the LXD version used in the tutorial from 6/stable to 5.21/stable. Testing on windows multipass (and possibly on base linux) revealed instability in creating machines for microceph while on 6/stable. 



#### Related Issues, PRs, and Discussions

[//]: Fixes https://github.com/charmed-hpc/docs/issues/143



