### PR TITLE
docs: url updates

### DIFF
--- a/.github/skills/generate-prometheus-alerts-reference/SKILL.md
+++ b/.github/skills/generate-prometheus-alerts-reference/SKILL.md
@@ -12,10 +12,10 @@ Scans the primary Charmed HPC charm repositories on GitHub for Prometheus alert 
 
 Use the GitHub MCP server tools (`mcp_github_get_file_contents`) to scan the following repositories for Prometheus alert rules:
 
-1. `charmed-hpc/slurm-charms` — look inside each charm directory under `charms/*/src/cos/alert_rules/prometheus/`
-2. `charmed-hpc/sssd-operator` — look under `src/cos/alert_rules/prometheus/`
-3. `charmed-hpc/filesystem-charms` — look inside each charm directory under `charms/*/src/cos/alert_rules/prometheus/`
-4. `charmed-hpc/apptainer-operator` — look under `src/cos/alert_rules/prometheus/`
+1. `canonical/slurm-charms` — look inside each charm directory under `charms/*/src/cos/alert_rules/prometheus/`
+2. `canonical/sssd-operator` — look under `src/cos/alert_rules/prometheus/`
+3. `canonical/filesystem-charms` — look inside each charm directory under `charms/*/src/cos/alert_rules/prometheus/`
+4. `canonical/apptainer-operator` — look under `src/cos/alert_rules/prometheus/`
 
 Alert rule files use the `.rule` or `.rules` extension and are in YAML format.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,12 @@
 # Contributing to Charmed HPC's documentation
 
-Do you want to contribute to [Charmed HPC's documentation](https://documentation.ubuntu.com/charmed-hpc/latest/)? You've come to
+Do you want to contribute to [Charmed HPC's documentation](https://ubuntu.com/hpc/docs)? You've come to
 the right place then! __Here is how you can get involved.__
 
 Please take a moment to review this document so that the contribution
-process will be easy and effective for everyone. Following these guidelines helps you communicate that you respect the maintainers
-managing Charmed HPC's documentation. In return, they will reciprocate that respect
-while addressing your issue or assessing your submitted changes and/or features.
+process will be easy and effective for everyone. Following these guidelines helps you communicate that you respect the maintainers managing Charmed HPC's documentation. In return, they will reciprocate that respect while addressing your issue or assessing your submitted changes and/or features.
 
-Have any questions? Feel free to ask them in the [Ubuntu High-Performance Computing
-Matrix chat](https://matrix.to/#/#hpc:ubuntu.com).
+Have any questions? Feel free to ask them in the [Ubuntu High-Performance Computing Matrix chat](https://matrix.to/#/#hpc:ubuntu.com) or the [High-Performance Computing category on the Ubuntu Discourse](https://discourse.ubuntu.com/c/project/hpc/151).
 
 ### Table of Contents
 
@@ -19,7 +16,6 @@ Matrix chat](https://matrix.to/#/#hpc:ubuntu.com).
 * [Bug Reports](#bug-reports)
 * [Enhancement Proposals](#enhancement-proposals)
 * [Pull Requests and Contributing Process](#pull-requests-and-contributing-process)
-* [Discussions](#discussions)
 * [Licensing](#licensing)
 
 
@@ -33,7 +29,7 @@ Charmed HPC's documentation is put together.
 The issue tracker is the preferred way for tracking [bug reports](#bug-reports) and [enhancement proposals](#enhancement-proposals), but please follow these guidelines for the issue tracker:
 
 * Please __do not__ use the issue tracker for personal issues and/or support requests.
-The [Discussions](#discussions) page is a better place to get help for personal support requests.
+The [Ubuntu High-Performance Computing Matrix chat](https://matrix.to/#/#hpc:ubuntu.com) or the [High-Performance Computing category on the Ubuntu Discourse](https://discourse.ubuntu.com/c/project/hpc/151) are better places to get help for personal support requests.
 
 * Please __do not__ derail or troll issues. Keep the discussion on track and have respect for the other
 users/contributors.
@@ -63,7 +59,7 @@ Can also be used for pull requests.
 * `good first issue` - Issues that the Charmed HPC documentation maintainers have determined to be suitable for first time contributors. 
 
 For a complete look at Charmed HPC's documentation labels, see the
-[project labels page](https://github.com/charmed-hpc/docs/labels).
+[project labels page](https://github.com/canonical/charmed-hpc-docs/labels).
 
 ## Bug Reports
 
@@ -104,10 +100,7 @@ Please make sure to select `bug` as the issue type.
 
 Enhancement proposals can be posted to the Charmed HPC documentation issue tracker, using the `enhancement` issue type.
 
-The Charmed HPC team may already know what they want to included in the documentation,
-but they are always open to new ideas and potential improvements. GitHub Discussions is
-a good place for discussing open-ended questions that pertain to the entire Charmed HPC
-project, but more focused enhancement proposal discussion can start within the issue
+The Charmed HPC team may already know what they want to included in the documentation, but they are always open to new ideas and potential improvements. The [Ubuntu High-Performance Computing Matrix chat](https://matrix.to/#/#hpc:ubuntu.com) or the [High-Performance Computing category on the Ubuntu Discourse](https://discourse.ubuntu.com/c/project/hpc/151) are good places for discussing open-ended questions that pertain to the entire Charmed HPC project, but more focused enhancement proposal discussions pertaining to documentation can start within the issue
 tracker.
 
 Please note that not all proposals may be incorporated into the documentation. Please
@@ -141,7 +134,7 @@ Charmed HPC's documentation:
    $ cd docs
 
    # Assign the original repo to a remote called "upstream"
-   $ git remote add upstream git@github.com:charmed-hpc/docs.git
+   $ git remote add upstream git@github.com:canonical/charmed-hpc-docs.git
    ```
 
 2. If you cloned the documentation a while ago, pull the latest changes from the
@@ -208,15 +201,7 @@ upstream Charmed HPC documentation repository:
 
 9. [Open a Pull Request](https://help.github.com/articles/about-pull-requests/) against the `main` branch by follow the guidelines and prompts within the Pull Request template that will generate when a pull request is started.
 
-
-## Discussions
-
-GitHub Discussions is a great place to connect with other Charmed HPC users to
-discuss potential enhancements, ask questions, and resolve issues. Charmed HPC users
-should remain respectful of each other. Discussion moderators reserve the right to
-suspend discussions and/or delete posts that do not follow this rule.
-
-
+## CODA
 
 Interested in learning more about how to contribute to open source documentation?
 Check out [Canonical's Open Documentation Academy](https://canonical.com/documentation/open-documentation-academy)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Charmed HPC documentation
 
-[![Documentation Status](https://readthedocs.com/projects/canonical-charmed-hpc/badge/?version=latest)](https://documentation.ubuntu.com/charmed-hpc/latest/)
+[![Documentation Status](https://readthedocs.com/projects/canonical-charmedhpc/badge/?version=latest)](https://ubuntu.com/hpc/docs)
 [![Matrix](https://img.shields.io/matrix/ubuntu-hpc%3Amatrix.org?logo=matrix&label=ubuntu-hpc)](https://matrix.to/#/#hpc:ubuntu.com)
 
 Charmed HPC's documentation 📑🔍
@@ -11,7 +11,7 @@ documentation, check out the [Getting Started](#-getting-started) and
 
 ## ✨ Getting started
 
-Periodically, issues within the docs repository will be labeled as `good first issue`. These issues are ideally the first place to get started helping with Charmed HPC's documentation. If there are currently no issues labeled `good first issue`, or none of the issues fit your interest, feel free to reach out on [Matrix](https://matrix.to/#/#hpc:ubuntu.com) and ask if the team has any suggestions. Otherwise, small pull requests for grammar and formatting are always a good place to start.
+Periodically, issues within the docs repository will be labeled as `good first issue`. These issues are ideally the first place to get started helping with Charmed HPC's documentation. If there are currently no issues labeled `good first issue`, or none of the issues fit your interest, feel free to reach out on the [Ubuntu High-Performance Computing Matrix chat](https://matrix.to/#/#hpc:ubuntu.com) or the [High-Performance Computing category on the Ubuntu Discourse](https://discourse.ubuntu.com/c/project/hpc/151) and ask if the team has any suggestions. Otherwise, small pull requests for grammar and formatting are always a good place to start.
 
 To provide bug reports or enhancement requests regarding _the documentation_, please see the corresponding sections in the [CONTRIBUTING](./CONTRIBUTING.md) file.
 
@@ -38,7 +38,6 @@ some links to help you get started:
 * [Contributing guidelines](./CONTRIBUTING.md)
 * [Join the conversation on Matrix](https://matrix.to/#/#hpc:ubuntu.com)
 * [Get the latest news on Discourse](https://discourse.ubuntu.com/c/hpc/151)
-* [Ask and answer questions on GitHub](https://github.com/orgs/charmed-hpc/discussions/categories/q-a)
 
 ## 📋 License
 

--- a/conf.py
+++ b/conf.py
@@ -250,6 +250,7 @@ linkcheck_ignore = [
     "https://matrix.to/#/#hpc:ubuntu.com",
     "https://charmhub.io/integrations/*", # Integrations page is very unstable sometimes
     "https://ceph.io", # site works but checker throws Internal Server Error 
+    "https://www.mysql.com", # Forbidden error via github workflow
 ]
 
 

--- a/conf.py
+++ b/conf.py
@@ -134,7 +134,7 @@ html_context = {
     #
     # NOTE: If set, links for viewing the documentation source files
     #       and creating GitHub issues are added at the bottom of each page.
-    "github_url": "https://github.com/charmed-hpc/docs",
+    "github_url": "https://github.com/canonical/charmed-hpc-docs",
     # Docs branch in the repo; used in links for viewing the source files
     #
     # TODO: To customise the branch, uncomment and update as needed.
@@ -170,7 +170,7 @@ if os.getenv("OPENAPI", ""):
 # - https://git.launchpad.net/example
 #
 html_theme_options = {
- 'source_edit_link': 'https://github.com/charmed-hpc/docs',
+ 'source_edit_link': 'https://github.com/canonical/charmed-hpc-docs',
 }
 
 # Project slug; see https://meta.discourse.org/t/what-is-category-slug/87897
@@ -249,6 +249,7 @@ linkcheck_ignore = [
     "https://jwt.io",
     "https://matrix.to/#/#hpc:ubuntu.com",
     "https://charmhub.io/integrations/*", # Integrations page is very unstable sometimes
+    "https://ceph.io", # site works but checker throws Internal Server Error 
 ]
 
 

--- a/contributing/code.md
+++ b/contributing/code.md
@@ -5,7 +5,7 @@ Charmed HPC is a open source project and welcomes community contributions. Pleas
 
 ## Report an issue
 
-To report an issue or bug, file an issue in the appropriate repository's issue tracker; the full list of repositories is provided below. If you are unsure which repository the issue should belong to, share the issue in the [Ubuntu High-Performance Computing Matrix chat](https://matrix.to/#/#hpc:ubuntu.com) or the [High-Performance Computing category on the Ubuntu Discourse](https://discourse.ubuntu.com/c/project/hpc/151).
+To report an issue or bug, file an issue in the appropriate repository's issue tracker; the full list of repositories can be found by filtering the Canonical GitHub organization by the [`charmed-hpc` topic](https://github.com/search?q=topic%3Acharmed-hpc%20org%3Acanonical&type=repositories). If you are unsure which repository the issue should belong to, share the issue in the [Ubuntu High-Performance Computing Matrix chat](https://matrix.to/#/#hpc:ubuntu.com) or the [High-Performance Computing category on the Ubuntu Discourse](https://discourse.ubuntu.com/c/project/hpc/151).
 
 
 When reporting a bug, please:
@@ -90,23 +90,6 @@ Adhering to the following process is the best way to have your contribution acce
    with a clear title and description against the `main` branch. Your pull request should also be focused and not contain commits that are not related to what you are contributing.
 
 9. Conditionally, open a corresponding Pull Request on the [`docs`](https://github.com/canonical/charmed-hpc-docs) repository, following the [canonical/charmed-hpc-docs CONTRIBUTING.md guidelines](https://github.com/canonical/charmed-hpc-docs/blob/main/CONTRIBUTING.md#pull-requests-and-contributing-process), if you are making user-facing changes.
-
-## Charmed HPC GitHub Code Repositories
-
-- [sssd-operator](https://github.com/canonical/sssd-operator)
-- [apptainer-operator](https://github.com/canonical/apptainer-operator)
-- [charmed-hpc-libs](https://github.com/canonical/charmed-hpc-libs)
-- [slurmutils](https://github.com/canonical/slurmutils)
-- [slurm-charms](https://github.com/canonical/slurm-charms)
-- [filesystem-charms](https://github.com/canonical/filesystem-charms)
-- [charmed-hpc-benchmarks](https://github.com/canonical/charmed-hpc-benchmarks)
-- [charmed-hpc-terraform](https://github.com/canonical/charmed-hpc-terraform)
-- [slurm-snap](https://github.com/canonical/slurm-snap)
-- [ondemand-snap](https://github.com/canonical/ondemand-snap)
-- [slurm-mail](https://github.com/canonical/slurm-mail)
-- [mysql-proxy-operator](https://github.com/canonical/mysql-proxy-operator)
-- [ood-portal-generator](https://github.com/canonical/ood-portal-generator)
-- [sysprober](https://github.com/canonical/sysprober)
 
 ## Further resources
 

--- a/contributing/code.md
+++ b/contributing/code.md
@@ -1,11 +1,12 @@
 (contributing-to-code)=
 # Contributing to Charmed HPC's code
 
-Charmed HPC is a open source project and welcomes community contributions. Please read through the following guidelines to best prepare yourself for making contributions. If you have questions, feel free to ask them in the [Ubuntu High-Performance Computing Matrix chat](https://matrix.to/#/#hpc:ubuntu.com) or in [Charmed HPC's GitHub Discussions](https://github.com/orgs/charmed-hpc/discussions). 
+Charmed HPC is a open source project and welcomes community contributions. Please read through the following guidelines to best prepare yourself for making contributions. If you have questions, feel free to ask them in the [Ubuntu High-Performance Computing Matrix chat](https://matrix.to/#/#hpc:ubuntu.com) or the [High-Performance Computing category on the Ubuntu Discourse](https://discourse.ubuntu.com/c/project/hpc/151). 
 
 ## Report an issue
 
-To report an issue or bug, file an issue in the appropriate [Charmed HPC GitHub Organization](https://github.com/charmed-hpc) repository's issue tracker. If you are unsure which repository the issue should belong to, share the issue in [Charmed HPC's GitHub Discussions](https://github.com/orgs/charmed-hpc/discussions).
+To report an issue or bug, file an issue in the appropriate repository's issue tracker; the full list of repositories is provided below. If you are unsure which repository the issue should belong to, share the issue in the [Ubuntu High-Performance Computing Matrix chat](https://matrix.to/#/#hpc:ubuntu.com) or the [High-Performance Computing category on the Ubuntu Discourse](https://discourse.ubuntu.com/c/project/hpc/151).
+
 
 When reporting a bug, please:
 
@@ -24,7 +25,7 @@ using the latest revision of the repository.
 
 ## Enhancement proposals
 
-While Charmed HPC's maintainers will often already have a plan for upcoming features, we welcome community ideas and potential improvements. [Charmed HPC's GitHub Discussions](https://github.com/orgs/charmed-hpc/discussions) is a good place for discussing open-ended questions, and more focused proposals can be created within a relevant repository's issue tracker.
+While Charmed HPC's maintainers will often already have a plan for upcoming features, we welcome community ideas and potential improvements. The [Ubuntu High-Performance Computing Matrix chat](https://matrix.to/#/#hpc:ubuntu.com) or the [High-Performance Computing category on the Ubuntu Discourse](https://discourse.ubuntu.com/c/project/hpc/151) are good places for discussing open-ended questions, and more focused proposals can be created within a relevant repository's issue tracker.
 
 ## Pull requests
 
@@ -45,7 +46,7 @@ Adhering to the following process is the best way to have your contribution acce
    cd <repository>
 
    # Assign the original repo to a remote called "upstream"
-   git remote add upstream https://github.com/charmed-hpc/<repository>.git
+   git remote add upstream https://github.com/canonical/<repository>.git
    ```
 
 2. If you cloned a while ago, pull the latest changes from the upstream repository:
@@ -88,14 +89,31 @@ Adhering to the following process is the best way to have your contribution acce
 8. [Open a Pull Request](https://help.github.com/articles/about-pull-requests/)
    with a clear title and description against the `main` branch. Your pull request should also be focused and not contain commits that are not related to what you are contributing.
 
-9. Conditionally, open a corresponding Pull Request on the [`docs`](https://github.com/charmed-hpc/docs) repository, following the [charmed-hpc/docs CONTRIBUTING.md guidelines](https://github.com/charmed-hpc/docs/blob/main/CONTRIBUTING.md#pull-requests-and-contributing-process), if you are making user-facing changes.
+9. Conditionally, open a corresponding Pull Request on the [`docs`](https://github.com/canonical/charmed-hpc-docs) repository, following the [canonical/charmed-hpc-docs CONTRIBUTING.md guidelines](https://github.com/canonical/charmed-hpc-docs/blob/main/CONTRIBUTING.md#pull-requests-and-contributing-process), if you are making user-facing changes.
+
+## Charmed HPC GitHub Code Repositories
+
+- [sssd-operator](https://github.com/canonical/sssd-operator)
+- [apptainer-operator](https://github.com/canonical/apptainer-operator)
+- [charmed-hpc-libs](https://github.com/canonical/charmed-hpc-libs)
+- [slurmutils](https://github.com/canonical/slurmutils)
+- [slurm-charms](https://github.com/canonical/slurm-charms)
+- [filesystem-charms](https://github.com/canonical/filesystem-charms)
+- [charmed-hpc-benchmarks](https://github.com/canonical/charmed-hpc-benchmarks)
+- [charmed-hpc-terraform](https://github.com/canonical/charmed-hpc-terraform)
+- [slurm-snap](https://github.com/canonical/slurm-snap)
+- [ondemand-snap](https://github.com/canonical/ondemand-snap)
+- [slurm-mail](https://github.com/canonical/slurm-mail)
+- [mysql-proxy-operator](https://github.com/canonical/mysql-proxy-operator)
+- [ood-portal-generator](https://github.com/canonical/ood-portal-generator)
+- [sysprober](https://github.com/canonical/sysprober)
 
 ## Further resources
 
 See the below resources for further guidance and useful references:
 
-* [Charmed HPC's main GitHub CONTRIBUTING guidelines](https://github.com/charmed-hpc/.github/blob/main/CONTRIBUTING.md)
-* [Charmed HPC's documentation CONTRIBUTING guidelines](https://github.com/charmed-hpc/docs/blob/main/CONTRIBUTING.md)
+* [Charmed HPC's main GitHub CONTRIBUTING guidelines](https://github.com/canonical/hpc-team/blob/main/CONTRIBUTING.md)
+* [Charmed HPC's documentation CONTRIBUTING guidelines](https://github.com/canonical/charmed-hpc-docs/blob/main/CONTRIBUTING.md)
 * [Python code style guide](https://pep8.org/)
 * [Juju documentation](https://documentation.ubuntu.com/juju)
 * [Charmcraft documentation](https://canonical-charmcraft.readthedocs-hosted.com/stable/)

--- a/contributing/documentation.md
+++ b/contributing/documentation.md
@@ -1,12 +1,12 @@
 (contributing-to-docs)=
 # Contributing to Charmed HPC's documentation
 
-Contributions to Charmed HPC's documentation are welcomed and encouraged. Please read through the following guidelines to best prepare yourself for contributing. If you have questions, feel free to ask them in the [Ubuntu High-Performance Computing Matrix chat](https://matrix.to/#/#hpc:ubuntu.com) or in [Charmed HPC's GitHub Discussions](https://github.com/orgs/charmed-hpc/discussions).
+Contributions to Charmed HPC's documentation are welcomed and encouraged. Please read through the following guidelines to best prepare yourself for contributing. If you have questions, feel free to ask them in the the [Ubuntu High-Performance Computing Matrix chat](https://matrix.to/#/#hpc:ubuntu.com) or the [High-Performance Computing category on the Ubuntu Discourse](https://discourse.ubuntu.com/c/project/hpc/151).
 
 (doc-structure)=
 ## Documentation structure
 
-The documentation is written in the [MyST](https://mystmd.org/) flavor of the Markdown mark-up language and uses the [Diátaxis](https://diataxis.fr/) framework for content organization. The raw document files all hosted in the [Charmed HPC docs repository](https://github.com/charmed-hpc/docs) on GitHub and use the [Sphinx-based starter pack](https://canonical-starter-pack.readthedocs-hosted.com/stable/) for theming, extensions, and rendering on [ReadtheDocs](https://about.readthedocs.com/). See Canonical's [MyST syntax guide](https://canonical-starter-pack.readthedocs-hosted.com/latest/reference/myst-syntax-reference/) for formatting and preferred usage guidance.
+The documentation is written in the [MyST](https://mystmd.org/) flavor of the Markdown mark-up language and uses the [Diátaxis](https://diataxis.fr/) framework for content organization. The raw document files all hosted in the [Charmed HPC docs repository](https://github.com/canonical/charmed-hpc-docs) on GitHub and use the [Sphinx-based starter pack](https://canonical-starter-pack.readthedocs-hosted.com/stable/) for theming, extensions, and rendering on [ReadtheDocs](https://about.readthedocs.com/). See Canonical's [MyST syntax guide](https://canonical-starter-pack.readthedocs-hosted.com/latest/reference/myst-syntax-reference/) for formatting and preferred usage guidance.
 
 ## Prerequisites
 
@@ -18,7 +18,7 @@ There are a couple prerequisites to contributing to Charmed HPC's documentation:
 
 ## Report an issue
 
-To report an error in spelling, grammar, content, or documentation code functionality, [file an issue](https://github.com/charmed-hpc/docs/issues) in Charmed HPC's bug tracker on GitHub.
+To report an error in spelling, grammar, content, or documentation code functionality, [file an issue](https://github.com/canonical/charmed-hpc-docs/issues) in Charmed HPC's bug tracker on GitHub.
 
 ## Simple update
 
@@ -62,7 +62,7 @@ To run the tests:
 | `make vale`{l=shell} | Check for style guide compliance |
 | `npx commitlint --from <start-ID> --to <end-ID> --verbose`{l=shell} | Check for commitlint compliance from git commit ID `<start-ID>` to commit ID `<end-ID>`|
 
-For more information on setting up the tests locally, see [Automatic checks](https://canonical-starter-pack.readthedocs-hosted.com/latest/reference/automatic_checks/) within the Canonical Starter Pack documentation.
+For more information on setting up the tests locally, see [Run documentation checks](https://documentation.ubuntu.com/sphinx-stack/latest/how-to/run-documentation-checks/) within the Canonical Sphinx Stack documentation.
 
 ### Test through GitHub
 

--- a/contributing/documentation.md
+++ b/contributing/documentation.md
@@ -6,7 +6,7 @@ Contributions to Charmed HPC's documentation are welcomed and encouraged. Please
 (doc-structure)=
 ## Documentation structure
 
-The documentation is written in the [MyST](https://mystmd.org/) flavor of the Markdown mark-up language and uses the [Diátaxis](https://diataxis.fr/) framework for content organization. The raw document files all hosted in the [Charmed HPC docs repository](https://github.com/canonical/charmed-hpc-docs) on GitHub and use the [Sphinx-based starter pack](https://canonical-starter-pack.readthedocs-hosted.com/stable/) for theming, extensions, and rendering on [ReadtheDocs](https://about.readthedocs.com/). See Canonical's [MyST syntax guide](https://canonical-starter-pack.readthedocs-hosted.com/latest/reference/myst-syntax-reference/) for formatting and preferred usage guidance.
+The documentation is written in the [MyST](https://mystmd.org/) flavor of the Markdown mark-up language and uses the [Diátaxis](https://diataxis.fr/) framework for content organization. The raw document files all hosted in the [Charmed HPC docs repository](https://github.com/canonical/charmed-hpc-docs) on GitHub and use the [Canonical Sphinx Stack](https://documentation.ubuntu.com/sphinx-stack/latest/) for theming, extensions, and rendering on [ReadtheDocs](https://about.readthedocs.com/). See Canonical's [MyST syntax guide](https://documentation.ubuntu.com/sphinx-stack/latest/reference/myst-syntax/) for formatting and preferred usage guidance.
 
 ## Prerequisites
 

--- a/contributing/index.md
+++ b/contributing/index.md
@@ -1,6 +1,6 @@
 # Contribute to Charmed HPC
 
-Charmed HPC is an open source project of the [Ubuntu High-Performance Computing community](https://ubuntu.com/community/governance/teams/hpc). Contributions to both the code and documentation are welcome. For questions, reach out on [Matrix](https://matrix.to/#/#hpc:ubuntu.com) or [GitHub Discussions](https://github.com/orgs/charmed-hpc/discussions/).
+Charmed HPC is an open source project of the [Ubuntu High-Performance Computing community](https://ubuntu.com/community/governance/teams/hpc). Contributions to both the code and documentation are welcome. For questions, reach out on the [Ubuntu High-Performance Computing Matrix chat](https://matrix.to/#/#hpc:ubuntu.com) or the [High-Performance Computing category on the Ubuntu Discourse](https://discourse.ubuntu.com/c/project/hpc/151).
 
 ## Contributing to Charmed HPC's documentation
 

--- a/explanation/high-availability.md
+++ b/explanation/high-availability.md
@@ -21,7 +21,7 @@ Charmed HPC uses Slurm's built-in HA support alongside [Juju's horizontal scalin
 
 For `slurmctld` HA to function, all `slurmctld` controllers require mounting of the same shared file system to provide a common [`StateSaveLocation`](https://slurm.schedmd.com/slurm.conf.html#OPT_StateSaveLocation) directory to hold controller state data. This directory governs the responsiveness and throughput of the cluster, so it should be hosted on a file system with low latency. It is therefore recommended that the file system **not be the same as the file system used for the cluster compute nodes** to avoid I/O-intensive user jobs from impacting `slurmctld` responsiveness.
 
-To allow for flexibility in choosing a shared file system for the `StateSaveLocation`, Charmed HPC implements support for the [`filesystem-client` charm](https://github.com/charmed-hpc/filesystem-charms) within the `slurmctld` charm. This enables users to integrate with the file system of their choice, such as their own CephFS deployment, a cloud-specific managed file system, or another that meets latency requirements.
+To allow for flexibility in choosing a shared file system for the `StateSaveLocation`, Charmed HPC implements support for the [`filesystem-client` charm](https://github.com/canonical/filesystem-charms) within the `slurmctld` charm. This enables users to integrate with the file system of their choice, such as their own CephFS deployment, a cloud-specific managed file system, or another that meets latency requirements.
 
 :::{admonition} Appropriate file system
 :class: warning
@@ -50,7 +50,7 @@ In an HA setup, all `slurmctld` instances require matching configuration files. 
 
 Similarly to `StateSaveLocation`, data in `/etc/slurm` is migrated to `/srv/slurmctld-statefs/etc/slurm` on `filesystem-client` integration. The `/etc/slurm` directory is then replaced with a symbolic link to `/srv/slurmctld-statefs/etc/slurm` on all `slurmctld` instances to ensure all access the same configuration files.
 
-To avoid data loss, any existing `/etc/slurm/` is backed up to a date-stamped directory on the unit's local disk, for example `/etc/slurm_20250620_161437` for a backup performed on 2025-06-20 at 16:14:37. To prevent non-leaders from reading partially written configuration files, updates to files are made atomically via [slurmutils](https://github.com/charmed-hpc/slurmutils/).
+To avoid data loss, any existing `/etc/slurm/` is backed up to a date-stamped directory on the unit's local disk, for example `/etc/slurm_20250620_161437` for a backup performed on 2025-06-20 at 16:14:37. To prevent non-leaders from reading partially written configuration files, updates to files are made atomically via [slurmutils](https://github.com/canonical/slurmutils/).
 
 The `slurmctld` charm leader in a Charmed HPC cluster handles all controller configuration operations. The leader generates cluster keys and all configuration files while non-leader units defer until these files appear in the shared storage.
 

--- a/howto/cleanup/cleanup-cloud-resources.md
+++ b/howto/cleanup/cleanup-cloud-resources.md
@@ -237,7 +237,7 @@ aws sso logout
 To clean up Google Cloud Platform and Google Kubernetes Engine (GKE) resources, it is assumed you have:
 
 
-* [Authenticated into the gcloud CLI](https://cloud.google.com/docs/authentication/gcloud#local)
+* [Authenticated into the gcloud CLI](https://cloud.google.com/docs/authentication/gcloud)
 * Bootstrapped a Juju controller on GCP
 * Added a GKE cluster to the controller
 

--- a/howto/deploy/deploy-shared-filesystem.md
+++ b/howto/deploy/deploy-shared-filesystem.md
@@ -13,8 +13,8 @@ cloud managed NFS server on the [`charmed-hpc-terraform`][hpc-tf] repository, wi
 [examples][nfs-tf-examples] on how to deploy the modules.
 :::
 
-[hpc-tf]: https://github.com/charmed-hpc/charmed-hpc-terraform
-[nfs-tf-examples]: https://github.com/charmed-hpc/charmed-hpc-terraform/blob/main/examples
+[hpc-tf]: https://github.com/canonical/charmed-hpc-terraform
+[nfs-tf-examples]: https://github.com/canonical/charmed-hpc-terraform/blob/main/examples
 
 ## Prerequisites
 
@@ -130,7 +130,7 @@ To integrate with an external CephFS share, you will require:
 
 Here, a Ceph cluster will be set up using [MicroCeph][ceph].
 
-[ceph]: https://canonical-microceph.readthedocs-hosted.com/en/v19.2.0-squid
+[ceph]: https://canonical-microceph.readthedocs-hosted.com/v19.2.0-squid
 
 First, launch a virtual machine using [LXD](https://ubuntu.com/lxd):
 

--- a/howto/deploy/deploy-slurm.md
+++ b/howto/deploy/deploy-slurm.md
@@ -2,7 +2,7 @@
 myst:
   html_meta:
     description: Instructions on how to use Juju to deploy Slurm in either a standalone or high-availability configuration as the workload manager of a Charmed HPC cluster.
-relatedlinks: "[Slurm&#32;website](https://slurm.schedmd.com/overview.html), [Slurm&#32;charms&#32;repository](https://github.com/charmed-hpc/slurm-charms)"
+relatedlinks: "[Slurm&#32;website](https://slurm.schedmd.com/overview.html), [Slurm&#32;charms&#32;repository](https://github.com/canonical/slurm-charms)"
 ---
 
 (howto-deploy-deploy-slurm)=

--- a/howto/initialize-cloud-environment.md
+++ b/howto/initialize-cloud-environment.md
@@ -396,7 +396,7 @@ the same GCP project. This may make some processes more complex if you have spec
 To use GCP as the machine cloud for your Charmed HPC cluster, you will need to have:
 
 * [Installed the gcloud CLI](https://cloud.google.com/sdk/docs/install)
-* [Authenticated into the gcloud CLI](https://cloud.google.com/docs/authentication/gcloud#local)
+* [Authenticated into the gcloud CLI](https://cloud.google.com/docs/authentication/gcloud)
 * [Adjusted quotas for suitable Compute Engine machine families](https://cloud.google.com/compute/resource-usage#cpu_quota)
 
 To decide on suitable instance types, it may be useful to refer to GCP's [Machine families resource and comparison guide][machines].
@@ -725,7 +725,7 @@ To use GKE as the Kubernetes cloud for your Charmed HPC cluster, you will need t
 
 * [Initialized a machine cloud](#howto-initialize-machine-cloud)
 * [Installed the `google-cloud-cli-gke-gcloud-auth-plugin` component](https://cloud.google.com/sdk/docs/components#additional_components)
-* [Authenticated into the gcloud CLI](https://cloud.google.com/docs/authentication/gcloud#local)
+* [Authenticated into the gcloud CLI](https://cloud.google.com/docs/authentication/gcloud)
 
 ### Set up default Service Account
 

--- a/howto/integrate/integrate-with-apptainer.md
+++ b/howto/integrate/integrate-with-apptainer.md
@@ -1,5 +1,5 @@
 ---
-relatedlinks: "[Apptainer&#32;admin&#32;documentation](https://apptainer.org/docs/admin/latest/), [Apptainer&#32;(Charmhub)](https://charmhub.io/apptainer), [Apptainer&#32;charm&#32;repository](https://github.com/charmed-hpc/apptainer-operator)"
+relatedlinks: "[Apptainer&#32;admin&#32;documentation](https://apptainer.org/docs/admin/latest/), [Apptainer&#32;(Charmhub)](https://charmhub.io/apptainer), [Apptainer&#32;charm&#32;repository](https://github.com/canonical/apptainer-operator)"
 ---
 
 (howto-manage-integrate-with-apptainer)=

--- a/howto/manage/manage-slurm.md
+++ b/howto/manage/manage-slurm.md
@@ -40,7 +40,7 @@ juju config slurmctld email-from-name="The my-cluster-name Admin Team"
 :::{code-block} terraform
 :caption: `main.tf`
 module "slurmctld" {
-  source      = "git::https://github.com/charmed-hpc/slurm-charms//charms/slurmctld/terraform"
+  source      = "git::https://github.com/canonical/slurm-charms//charms/slurmctld/terraform"
   model_uuid  = juju_model.slurm.uuid
   config = {
     email-from-name = "The my-cluster-name Admin Team"
@@ -94,7 +94,7 @@ juju add-unit -n 1 slurmctld
 :::{code-block} terraform
 :caption: `main.tf`
 module "filesystem-client" {
-  source      = "git::https://github.com/charmed-hpc/filesystem-charms//charms/filesystem-client/terraform"
+  source      = "git::https://github.com/canonical/filesystem-charms//charms/filesystem-client/terraform"
   model_uuid  = juju_model.slurm.uuid
 }
 
@@ -113,7 +113,7 @@ resource "juju_integration" "provider_to_filesystem" {
 }
 
 module "slurmctld" {
-  source      = "git::https://github.com/charmed-hpc/slurm-charms//charms/slurmctld/terraform"
+  source      = "git::https://github.com/canonical/slurm-charms//charms/slurmctld/terraform"
   model_uuid  = juju_model.slurm.uuid
   constraints = "virt-type=virtual-machine"
   units       = 2

--- a/howto/run-workloads/use-apptainer.md
+++ b/howto/run-workloads/use-apptainer.md
@@ -176,7 +176,7 @@ cat job.out
 Hello from Python 3.13.3 (main, Aug 14 2025, 11:53:40) [GCC 14.2.0]!
 :::
 
-[//]: # (TODO: Uncomment once https://github.com/charmed-hpc/slurm-charms/issues/143 is fixed.)
+[//]: # (TODO: Uncomment once https://github.com/canonical/slurm-charms/issues/143 is fixed.)
 <!--
 ### Using the `--container` flag with `sbatch`{l=shell}
 

--- a/index.md
+++ b/index.md
@@ -1,11 +1,6 @@
 # Charmed HPC
 
 Charmed HPC is a platform for managing high-performance computing clusters. It automates the lifecycle of essential cluster software and processes, such as workload management, shared storage, GPU access, and high-bandwidth networking. This allows operations teams and systems administrators to focus on running workloads rather than maintaining infrastructure.
-<!-- Charmed HPC is a versatile high-performance computing platform that facilitates the set up and maintenance of HPC clusters. This is done by autonomizing the deployment, integration, and life-cycle management of essential cluster software that enables users to run modern workloads at scale.
-
-Charmed HPC spins up turnkey clusters on a variety of cloud platforms to support write-once, run-anywhere user workloads. It also provides the necessary integrations for GPUs, high bandwidth networking, and shared storage.
-
-The platform enables organizations to focus on obtaining key insights and making data-driven decisions by providing an HPC platform that solves the complexity of deploying and operating an HPC cluster at scale. It is directly beneficial to operations teams and system administrators looking to take full advantage of their HPC hardware, available storage configurations, and high bandwidth networking while minimizing cluster downtime for routine maintenance. -->
 
 ---
 
@@ -36,14 +31,14 @@ Charmed HPC is an Ubuntu community project. It's an open source project that war
 
 **Get involved**
 
-* [Support](https://github.com/orgs/charmed-hpc/discussions/categories/support)
+* [Support](https://discourse.ubuntu.com/c/project/hpc/151)
 * [Online chat](https://matrix.to/#/#hpc:ubuntu.com)
 * [Contribute](contributing/index)
 
 <!-- **Releases**
 
 * [Release notes](https://discourse.ubuntu.com/c/hpc/151)
-* [Roadmap](https://github.com/orgs/charmed-hpc/projects) -->
+* [Roadmap](https://github.com/orgs/canonical/projects) -->
 
 **Governance and policies**
 

--- a/reference/glossary.md
+++ b/reference/glossary.md
@@ -145,7 +145,7 @@ Slurm
 Slurm charms
     A set of {term}`charmed operators <Charm>` that deploy and manage {term}`Slurm`.
 
-    Resources: [Slurm charms repository {octicon}`link-external`](https://github.com/charmed-hpc/slurm-charms)
+    Resources: [Slurm charms repository {octicon}`link-external`](https://github.com/canonical/slurm-charms)
 
 `slurmctld`
     Slurm central management/controller daemon. Schedules jobs and monitors other components.
@@ -172,7 +172,7 @@ Slurm charms
 `slurmutils`
     Python library for facilitating edits to Slurm configuration files.
 
-    Resources: [slurmutils GitHub {octicon}`link-external`](https://github.com/charmed-hpc/slurmutils)
+    Resources: [slurmutils GitHub {octicon}`link-external`](https://github.com/canonical/slurmutils)
 
 System Security Services Daemon (`sssd`)
     A daemon that manages the retrieval and caching of user credentials and attributes from remote

--- a/reference/performance.md
+++ b/reference/performance.md
@@ -7,7 +7,7 @@ myst:
 (reference-performance)=
 # Performance
 
-Performance values for the [Charmed HPC Benchmarks](https://github.com/charmed-hpc/charmed-hpc-benchmarks/) running on Microsoft Azure are provided on this page. Steps for reproducing these results are available in the [benchmarking suite documentation](https://github.com/charmed-hpc/charmed-hpc-benchmarks/blob/main/README.md). These results are intended to provided best-possible marks for performance to help guide tuning and identification of bottlenecks. Real-world performance may fluctuate depending on factors such as varying cluster workloads and resource contention.
+Performance values for the [Charmed HPC Benchmarks](https://github.com/canonical/charmed-hpc-benchmarks/) running on Microsoft Azure are provided on this page. Steps for reproducing these results are available in the [benchmarking suite documentation](https://github.com/canonical/charmed-hpc-benchmarks/blob/main/README.md). These results are intended to provided best-possible marks for performance to help guide tuning and identification of bottlenecks. Real-world performance may fluctuate depending on factors such as varying cluster workloads and resource contention.
 
 ## Metrics
 

--- a/reference/underlying-projects-and-dependencies.md
+++ b/reference/underlying-projects-and-dependencies.md
@@ -19,13 +19,13 @@ Core projects are projects that are maintained directly as part of Charmed HPC.
 : project, source code, bug report
 :widths: 15, 10, 10
 
-slurm-charms, [Source](https://github.com/charmed-hpc/slurm-charms), [Issue tracker](https://github.com/charmed-hpc/slurm-charms/issues)
-filesystem-charms, [Source](https://github.com/charmed-hpc/filesystem-charms), [Issue tracker](https://github.com/charmed-hpc/filesystem-charms/issues)
+slurm-charms, [Source](https://github.com/canonical/slurm-charms), [Issue tracker](https://github.com/canonical/slurm-charms/issues)
+filesystem-charms, [Source](https://github.com/canonical/filesystem-charms), [Issue tracker](https://github.com/canonical/filesystem-charms/issues)
 sssd-operator, [Source](https://github.com/canonical/sssd-operator), [Issue tracker](https://github.com/canonical/sssd-operator/issues)
-apptainer-operator, [Source](https://github.com/charmed-hpc/apptainer-operator), [Issue tracker](https://github.com/charmed-hpc/apptainer-operator/issues)
-slurmutils, [Source](https://github.com/charmed-hpc/slurmutils), [Issue tracker](https://github.com/charmed-hpc/slurmutils/issues)
-hpc-libs, [Source](https://github.com/charmed-hpc/hpc-libs), [Issue tracker](https://github.com/charmed-hpc/hpc-libs/issues)
-charmed-hpc-terraform, [Source](https://github.com/charmed-hpc/charmed-hpc-terraform), [Issue tracker](https://github.com/charmed-hpc/charmed-hpc-terraform/issues)
+apptainer-operator, [Source](https://github.com/canonical/apptainer-operator), [Issue tracker](https://github.com/canonical/apptainer-operator/issues)
+slurmutils, [Source](https://github.com/canonical/slurmutils), [Issue tracker](https://github.com/canonical/slurmutils/issues)
+charmed-hpc-libs, [Source](https://github.com/canonical/charmed-hpc-libs), [Issue tracker](https://github.com/canonical/charmed-hpc-libs/issues)
+charmed-hpc-terraform, [Source](https://github.com/canonical/charmed-hpc-terraform), [Issue tracker](https://github.com/canonical/charmed-hpc-terraform/issues)
 :::
 
 ### Dependencies
@@ -130,15 +130,15 @@ Charmed HPC uses integrations to dictate how charmed applications communicate wi
 : integration, interface implementation
 :widths: 15, 10
 
-[sackd](https://charmhub.io/integrations/sackd), [Charm library](https://github.com/charmed-hpc/hpc-libs/blob/main/src/hpc_libs/interfaces/slurm/sackd.py)
-slurmctld, [Charm library](https://github.com/charmed-hpc/hpc-libs/blob/main/src/hpc_libs/interfaces/slurm/common.py)
-[slurmd](https://charmhub.io/integrations/slurmd), [Charm library](https://github.com/charmed-hpc/hpc-libs/blob/main/src/hpc_libs/interfaces/slurm/slurmd.py)
-[slurmdbd](https://charmhub.io/integrations/slurmdbd), [Charm library](https://github.com/charmed-hpc/hpc-libs/blob/main/src/hpc_libs/interfaces/slurm/slurmdbd.py)
-[slurmrestd](https://charmhub.io/integrations/slurmrestd), [Charm library](https://github.com/charmed-hpc/hpc-libs/blob/main/src/hpc_libs/interfaces/slurm/slurmrestd.py)
-[slurm-oci-runtime](https://charmhub.io/integrations/slurm-oci-runtime), [Charm library](https://github.com/charmed-hpc/hpc-libs/blob/main/src/hpc_libs/interfaces/slurm/oci_runtime.py)
-[cos_agent](https://charmhub.io/integrations/cos_agent), [Charm library](https://charmhub.io/grafana-agent/libraries/cos_agent)
-[ldap](https://charmhub.io/integrations/ldap/), [Charm library](https://charmhub.io/glauth-k8s/libraries/ldap)
-[mysql_client](https://charmhub.io/integrations/mysql_client), [Charm library](https://charmhub.io/data-platform-libs/libraries/data_interfaces)
-[filesystem_info](https://charmhub.io/integrations/filesystem_info), [Charm library](https://charmhub.io/filesystem-client/libraries/filesystem_info)
-[mount_info](https://charmhub.io/integrations/mount_info), [Charm library](https://charmhub.io/filesystem-client/libraries/mount_info)
+sackd, [Implementation](https://github.com/canonical/slurm-charms/blob/main/internal/sackd-interface/README.md)
+slurmctld, [Implementation](https://github.com/canonical/slurm-charms/blob/main/pkg/slurmctld-interface/README.md)
+slurmd, [Implementation](https://github.com/canonical/slurm-charms/blob/main/internal/slurmd-interface/README.md)
+slurmdbd, [Implementation](https://github.com/canonical/slurm-charms/blob/main/internal/slurmdbd-interface/README.md)
+slurmrestd, [Implementation](https://github.com/canonical/slurm-charms/blob/main/internal/slurmrestd-interface/README.md)
+slurm-oci-runtime, [Implementation](https://github.com/canonical/slurm-charms/blob/main/pkg/slurm-oci-runtime-interface/README.md)
+cos_agent, [Implementation](https://charmhub.io/grafana-agent/libraries/cos_agent)
+ldap, [Implementation](https://charmhub.io/glauth-k8s/libraries/ldap)
+mysql_client, [Implementation](https://charmhub.io/data-platform-libs/libraries/data_interfaces)
+filesystem_info, [Implementation](https://charmhub.io/filesystem-client/libraries/filesystem_info)
+mount_info, [Implementation](https://charmhub.io/filesystem-client/libraries/mount_info)
 :::

--- a/reuse/howto/setup/deploy-identity-provider/common/sssd.tf
+++ b/reuse/howto/setup/deploy-identity-provider/common/sssd.tf
@@ -28,7 +28,7 @@ data "juju_application" "slurmd" {
 }
 
 module "sssd" {
-  source     = "git::https://github.com/charmed-hpc/sssd-operator//terraform"
+  source     = "git::https://github.com/canonical/sssd-operator//terraform"
   model_uuid = data.juju_model.slurm.uuid
 }
 

--- a/reuse/howto/setup/deploy-slurm/slurm-ha.tf
+++ b/reuse/howto/setup/deploy-slurm/slurm-ha.tf
@@ -1,5 +1,5 @@
 module "filesystem-client" {
-  source     = "git::https://github.com/charmed-hpc/filesystem-charms//charms/filesystem-client/terraform"
+  source     = "git::https://github.com/canonical/filesystem-charms//charms/filesystem-client/terraform"
   model_uuid  = juju_model.slurm.uuid
 }
 
@@ -18,7 +18,7 @@ resource "juju_integration" "provider_to_filesystem" {
 }
 
 module "slurmctld" {
-  source      = "git::https://github.com/charmed-hpc/slurm-charms//charms/slurmctld/terraform"
+  source      = "git::https://github.com/canonical/slurm-charms//charms/slurmctld/terraform"
   model_uuid  = juju_model.slurm.uuid
   units       = 2
 }

--- a/reuse/howto/setup/deploy-slurm/slurm-lxd.tf
+++ b/reuse/howto/setup/deploy-slurm/slurm-lxd.tf
@@ -1,29 +1,29 @@
 module "sackd" {
-  source      = "git::https://github.com/charmed-hpc/slurm-charms//charms/sackd/terraform"
+  source      = "git::https://github.com/canonical/slurm-charms//charms/sackd/terraform"
   model_uuid  = juju_model.slurm.uuid
   constraints = "virt-type=virtual-machine"
 }
 
 module "slurmctld" {
-  source      = "git::https://github.com/charmed-hpc/slurm-charms//charms/slurmctld/terraform"
+  source      = "git::https://github.com/canonical/slurm-charms//charms/slurmctld/terraform"
   model_uuid  = juju_model.slurm.uuid
   constraints = "virt-type=virtual-machine"
 }
 
 module "slurmd" {
-  source      = "git::https://github.com/charmed-hpc/slurm-charms//charms/slurmd/terraform"
+  source      = "git::https://github.com/canonical/slurm-charms//charms/slurmd/terraform"
   model_uuid  = juju_model.slurm.uuid
   constraints = "virt-type=virtual-machine"
 }
 
 module "slurmdbd" {
-  source      = "git::https://github.com/charmed-hpc/slurm-charms//charms/slurmdbd/terraform"
+  source      = "git::https://github.com/canonical/slurm-charms//charms/slurmdbd/terraform"
   model_uuid  = juju_model.slurm.uuid
   constraints = "virt-type=virtual-machine"
 }
 
 module "slurmrestd" {
-  source      = "git::https://github.com/charmed-hpc/slurm-charms//charms/slurmrestd/terraform"
+  source      = "git::https://github.com/canonical/slurm-charms//charms/slurmrestd/terraform"
   model_uuid  = juju_model.slurm.uuid
   constraints = "virt-type=virtual-machine"
 }

--- a/reuse/howto/setup/deploy-slurm/slurm.tf
+++ b/reuse/howto/setup/deploy-slurm/slurm.tf
@@ -15,27 +15,27 @@ resource "juju_model" "slurm" {
 }
 
 module "sackd" {
-  source      = "git::https://github.com/charmed-hpc/slurm-charms//charms/sackd/terraform"
+  source      = "git::https://github.com/canonical/slurm-charms//charms/sackd/terraform"
   model_uuid  = juju_model.slurm.uuid
 }
 
 module "slurmctld" {
-  source      = "git::https://github.com/charmed-hpc/slurm-charms//charms/slurmctld/terraform"
+  source      = "git::https://github.com/canonical/slurm-charms//charms/slurmctld/terraform"
   model_uuid  = juju_model.slurm.uuid
 }
 
 module "slurmd" {
-  source      = "git::https://github.com/charmed-hpc/slurm-charms//charms/slurmd/terraform"
+  source      = "git::https://github.com/canonical/slurm-charms//charms/slurmd/terraform"
   model_uuid  = juju_model.slurm.uuid
 }
 
 module "slurmdbd" {
-  source      = "git::https://github.com/charmed-hpc/slurm-charms//charms/slurmdbd/terraform"
+  source      = "git::https://github.com/canonical/slurm-charms//charms/slurmdbd/terraform"
   model_uuid  = juju_model.slurm.uuid
 }
 
 module "slurmrestd" {
-  source      = "git::https://github.com/charmed-hpc/slurm-charms//charms/slurmrestd/terraform"
+  source      = "git::https://github.com/canonical/slurm-charms//charms/slurmrestd/terraform"
   model_uuid  = juju_model.slurm.uuid
 }
 

--- a/reuse/tutorial/charmed-hpc-tutorial-cloud-init.yml
+++ b/reuse/tutorial/charmed-hpc-tutorial-cloud-init.yml
@@ -32,14 +32,14 @@ write_files:
     defer: true
     source:
       uri: |
-        https://raw.githubusercontent.com/charmed-hpc/docs/refs/heads/main/reuse/tutorial/mpi_hello_world.c
+        https://raw.githubusercontent.com/canonical/charmed-hpc-docs/refs/heads/main/reuse/tutorial/mpi_hello_world.c
   - path: /home/ubuntu/submit_hello.sh
     owner: ubuntu:ubuntu
     permissions: !!str "0664"
     defer: true
     source:
       uri: |
-        https://raw.githubusercontent.com/charmed-hpc/docs/refs/heads/main/reuse/tutorial/submit_hello.sh
+        https://raw.githubusercontent.com/canonical/charmed-hpc-docs/refs/heads/main/reuse/tutorial/submit_hello.sh
   # Container workload dependencies.
   - path: /home/ubuntu/generate.py
     owner: ubuntu:ubuntu
@@ -47,25 +47,25 @@ write_files:
     defer: true
     source:
       uri: |
-        https://raw.githubusercontent.com/charmed-hpc/docs/refs/heads/main/reuse/tutorial/generate.py
+        https://raw.githubusercontent.com/canonical/charmed-hpc-docs/refs/heads/main/reuse/tutorial/generate.py
   - path: /home/ubuntu/workload.py
     owner: ubuntu:ubuntu
     permissions: !!str "0664"
     defer: true
     source:
       uri: |
-        https://raw.githubusercontent.com/charmed-hpc/docs/refs/heads/main/reuse/tutorial/workload.py
+        https://raw.githubusercontent.com/canonical/charmed-hpc-docs/refs/heads/main/reuse/tutorial/workload.py
   - path: /home/ubuntu/workload.def
     owner: ubuntu:ubuntu
     permissions: !!str "0664"
     defer: true
     source:
       uri: |
-        https://raw.githubusercontent.com/charmed-hpc/docs/refs/heads/main/reuse/tutorial/workload.def
+        https://raw.githubusercontent.com/canonical/charmed-hpc-docs/refs/heads/main/reuse/tutorial/workload.def
   - path: /home/ubuntu/submit_apptainer_mascot.sh
     owner: ubuntu:ubuntu
     permissions: !!str "0664"
     defer: true
     source:
       uri: |
-       https://raw.githubusercontent.com/charmed-hpc/docs/refs/heads/main/reuse/tutorial/submit_apptainer_mascot.sh
+       https://raw.githubusercontent.com/canonical/charmed-hpc-docs/refs/heads/main/reuse/tutorial/submit_apptainer_mascot.sh


### PR DESCRIPTION
# Pre-submission checklist

 * [x] I read and followed the [CONTRIBUTING guidelines](../CONTRIBUTING.md).
 * [x] I have ensured that the documentation tests complete successfully.
 * [x] I have added a metadata description at the top of any new page.

## Summary of Changes

[//]: # (Please summarize your commits here. For any complex or contentious changes, please also provide justifications.)

Update to URLs within the documentation following the migration of the Charmed HPC repos to the Canonical org and the domain migration of the documentation to ubuntu.com/hpc/docs. Also includes:
* Updates to previous mentions of GitHub discussions as that is an org-based feature and not feasible with the repos in the Canonical org. 
* Updates to links in underlying projects Integrations section
* With no org to point users/devs to, a link to a charmed-hpc filter was added

#### Related Issues, PRs, and Discussions

[//]: # (Please link to related issues, pull requests, and discussions here - especially corresponding code PRs. If your PR has no related issues, PRs, or discussions, please provide a justification for this PR here instead.)


- Fixes https://github.com/canonical/charmed-hpc-docs/issues/140
